### PR TITLE
add test framework for api routes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: npm install
       - run: npm ci
       - run: npm run build --if-present
       - name: Install dependencies

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,3 +20,25 @@ httpServer.listen(3000);
 
 SocketServer.initialize(httpServer);
 const newPokerTable = PokerTable.createPokerTable('table_1', 2);
+
+export default httpServer;
+
+// Function to shut down the server (used in tests)
+async function shutDown(): Promise<void> {
+  // Close socket connections here (if applicable)
+  // For example: SocketServer.closeAllConnections();
+
+  // Close the HTTP server
+  return new Promise((resolve, reject) => {
+    httpServer.close((err) => {
+      if (err) {
+        console.error('Error shutting down the server:', err);
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export { shutDown };

--- a/backend/src/routes/actions.test.ts
+++ b/backend/src/routes/actions.test.ts
@@ -1,0 +1,70 @@
+// external modules
+import request from 'supertest';
+
+// internal modules
+import httpServer, { shutDown } from '../index';
+import Logger from '../utils/Logger';
+
+// mocks (not all used here, but leaving cos it could be in future)
+import {
+  mockJoinRoomSuccess,
+  mockJoinRoomError,
+  mockSendEventToRoomSuccess,
+  mockSendEventToRoomError,
+} from './roomMocks';
+
+import Rooms from '../sockets/Rooms';
+import Result, { ResultSuccess, ResultError } from '../shared/Result';
+
+const debug = Logger.newDebugger('test:tables');
+
+describe('tables.join', () => {
+  // TODO: will eventually need to add the table they are sitting at but this is hardcoded
+  // for now. See third commented out test
+  it('should seat a player to a table', async () => {
+    const res = await request(httpServer).post('/api/actions/tables.join').send({
+      selectedSeatNumber: 'seat-1',
+      socketId: 'abc123',
+    });
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.ok).toEqual(true);
+  });
+
+  it('should error when the seat is already taken', async () => {
+    jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
+    await request(httpServer).post('/api/actions/tables.join').send({
+      selectedSeatNumber: 'seat-1',
+      socketId: 'abc123',
+    });
+    const res = await request(httpServer).post('/api/actions/tables.join').send({
+      selectedSeatNumber: 'seat-1',
+      socketId: 'def456',
+    });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.ok).toEqual(false);
+    expect(res.body.error).toEqual('Seat is already taken');
+  });
+
+  // it('should error when the table doesnt exist', async () => {
+  //   mockSendEventToRoomError();
+  //   const res = await request(httpServer).post('/api/actions/tables.join').send({
+  //     table: 'table_doesnt_exist',
+  //     selectedSeatNumber: 'seat-1',
+  //     socketId: 'abc123',
+  //   });
+
+  //   expect(res.statusCode).toEqual(200);
+  //   expect(res.body.ok).toEqual(false);
+  //   expect(res.body.error).toEqual('Room not found');
+  // });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Shut down the server after all tests
+  afterAll(async () => {
+    await shutDown();
+  });
+});

--- a/backend/src/routes/roomMocks.ts
+++ b/backend/src/routes/roomMocks.ts
@@ -1,0 +1,20 @@
+// roomMocks.js
+import Rooms from '../sockets/Rooms';
+
+import Result, { ResultSuccess, ResultError } from '../shared/Result';
+
+export const mockJoinRoomSuccess = () => {
+  jest.spyOn(Rooms, 'joinRoom').mockImplementation(() => Result.success());
+};
+
+export const mockJoinRoomError = () => {
+  jest.spyOn(Rooms, 'joinRoom').mockImplementation(() => new ResultError('Mocked error'));
+};
+
+export const mockSendEventToRoomSuccess = () => {
+  jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => Result.success());
+};
+
+export const mockSendEventToRoomError = () => {
+  jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
+};

--- a/backend/src/tests/HelloWorld.spec.ts
+++ b/backend/src/tests/HelloWorld.spec.ts
@@ -1,7 +1,0 @@
-import HelloWorld from './HelloWorld';
-
-describe('HelloWorld', () => {
-  it('should return "Hello World"', () => {
-    expect(HelloWorld()).toBe('Hello World');
-  });
-});

--- a/backend/src/tests/HelloWorld.ts
+++ b/backend/src/tests/HelloWorld.ts
@@ -1,3 +1,0 @@
-export default function helloWorld(): string {
-  return 'Hello World';
-}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "devDependencies": {
     "@types/jest": "^29.5.5",
     "@types/node": "^20.8.4",
+    "@types/supertest": "^2.0.16",
     "concurrently": "^8.2.1",
-    "husky": "^8.0.3"
+    "husky": "^8.0.3",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
### Description

For endpoints we need a way to unit test. This PR adds supertest package for doing this. Also mock endpoints

### How to test

<!--- Steps on how to test this change  --->

Run `npm run test` (don't forget to install new packages)

### Task

CU-86cu3hetb

### Checklist

<!--- X off relevant items for this change --->

- [x] Added unit tests
- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
