### PR TITLE
fix: bug with checking existing seats

### DIFF
--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -49,6 +49,8 @@ export default class PokerTable {
             if (seat.playerId == clientId ){
                 return Result.error('Player is already sitting at the table');
             }
+        }
+        for (const seat of table.seats) {
             // Check if the seat is already taken by someone else
             if (seat.seatNumber == seatNumber) {
                 if (seat.isTaken){


### PR DESCRIPTION
### Description

Found a bug where it would sit you down on both seats if you sat at the second seat first. Now I've separated the checks so that we first check all seats for if player is already seated at the table and then check each seat for whether it is taken by someone else.

### How to test

1. Start app 
2. Click on second seat (on the right)
3. Click on the first seat (on the left)
4. You should see an error in the console logs that the user is already sitting down (before it would let you sit down at both)

### Task

NA

### Checklist

<!--- X off relevant items for this change --->

- [ ] Added unit tests
- [ ] Added learning objectives to clickup task
- [ ] Added new package information to appropriate README
