### PR TITLE
docs: add pr style guide

### DIFF
--- a/docs/pr_style_guide.md
+++ b/docs/pr_style_guide.md
@@ -1,0 +1,21 @@
+# PR Style Guide
+
+**Prefix commit messages and PR titles:**
+
+Keep lower case with colon:
+
+`fix: bug with pot calculation`
+
+| prefix    | description                                                                                                        |
+| --------- | ------------------------------------------------------------------------------------------------------------------ |
+| fix:      | Indicates a bug fix or correction of unexpected behavior.                                                          |
+| feat:     | Introduces a new feature or enhancement.                                                                           |
+| refactor: | Code changes that neither fix a bug nor add a feature but improve structure or readability.                        |
+| docs:     | Changes or additions to documentation only.                                                                        |
+| style:    | Formatting changes that don't affect the code's functionality (white-space, formatting, missing semi-colons, etc). |
+| tests:    | Adding missing tests or correcting existing tests.                                                                 |
+| chore:    | Maintenance tasks that don't modify src or test files (e.g., changes to the build process).                        |
+| perf:     | Performance improvements.                                                                                          |
+| ci:       | Changes to the continuous integration configuration files and scripts.                                             |
+| revert:   | Reverts a previous commit or PR.                                                                                   |
+| wip"      | Work in Progress, used when a PR is not ready for review.                                                          |


### PR DESCRIPTION
### Description

This PR adds a starter style guide for the repo which currently only includes the prefixes we should try use