### PR TITLE
refactor: simplify api creation and calling 

### DIFF
--- a/backend/src/routes/apiMethods.ts
+++ b/backend/src/routes/apiMethods.ts
@@ -6,4 +6,5 @@ export interface ApiMethodShape {
 export const ApiMethods: { [key: string]: ApiMethodShape } = {
   // add entries for each API method
   tablesJoin: { httpMethod: 'post', path: 'tables.join', handler: '../handlers/actions/TablesJoinHandler.ts' },
+  tablesLeave: { httpMethod: 'post', path: 'tables.leave', handler: '../handlers/actions/TablesLeaveHandler.ts' },
 } as const;

--- a/backend/src/routes/apiMethods.ts
+++ b/backend/src/routes/apiMethods.ts
@@ -1,0 +1,9 @@
+export interface ApiMethodShape {
+  httpMethod: 'get' | 'post' | 'put' | 'delete' | 'patch';
+  path: string;
+  handler: string;
+}
+export const ApiMethods: { [key: string]: ApiMethodShape } = {
+  // add entries for each API method
+  tablesJoin: { httpMethod: 'post', path: 'tables.join', handler: '../handlers/actions/TablesJoinHandler.ts' },
+} as const;

--- a/backend/src/routes/routeConfig.ts
+++ b/backend/src/routes/routeConfig.ts
@@ -15,8 +15,18 @@ const routes: RouteConfig[] = [
   {
     httpMethod: 'post',
     path: '/actions/tables.leave',
-    handler: '../handlers/actions/TablesLeaveHandler.ts'
-  }
+    handler: '../handlers/actions/TablesLeaveHandler.ts',
+  },
 ];
+import { ApiMethodShape, ApiMethods } from './apiMethods';
+
+const routes: ApiMethodShape[] = Object.keys(ApiMethods).map((key) => {
+  const apiMethod = ApiMethods[key as keyof typeof ApiMethods];
+  return {
+    httpMethod: apiMethod.httpMethod,
+    path: `/actions/${apiMethod.path}`,
+    handler: apiMethod.handler,
+  };
+});
 
 export default routes;

--- a/backend/src/routes/routeConfig.ts
+++ b/backend/src/routes/routeConfig.ts
@@ -5,19 +5,6 @@ interface RouteConfig {
   handler: string; // Path to the router or handler file
 }
 
-// Define the route configurations
-const routes: RouteConfig[] = [
-  {
-    httpMethod: 'post',
-    path: '/actions/tables.join',
-    handler: '../handlers/actions/TablesJoinHandler.ts',
-  },
-  {
-    httpMethod: 'post',
-    path: '/actions/tables.leave',
-    handler: '../handlers/actions/TablesLeaveHandler.ts',
-  },
-];
 import { ApiMethodShape, ApiMethods } from './apiMethods';
 
 const routes: ApiMethodShape[] = Object.keys(ApiMethods).map((key) => {

--- a/backend/src/shared/api/ApiMethodMap.ts
+++ b/backend/src/shared/api/ApiMethodMap.ts
@@ -1,0 +1,11 @@
+import { PlayerSitOutput, PlayerSitPayload } from './types/PlayerSit';
+
+export interface ApiMethodMap {
+  // Add entries for each API method
+  'tables.join': {
+    request: PlayerSitPayload;
+    response: PlayerSitOutput;
+  };
+}
+
+export type ApiMethod = keyof ApiMethodMap;

--- a/backend/src/shared/api/ApiMethodMap.ts
+++ b/backend/src/shared/api/ApiMethodMap.ts
@@ -1,10 +1,15 @@
-import { PlayerSitOutput, PlayerSitPayload } from './types/PlayerSit';
+import { PlayerSitPayload, PlayerSitOutput } from './types/PlayerSit';
+import { PlayerLeavePayload, PlayerLeaveOutput } from './types/PlayerLeave';
 
 export interface ApiMethodMap {
   // Add entries for each API method
   'tables.join': {
     request: PlayerSitPayload;
     response: PlayerSitOutput;
+  };
+  'tables.leave': {
+    request: PlayerLeavePayload;
+    response: PlayerLeaveOutput;
   };
 }
 

--- a/backend/src/shared/api/types/PlayerSit.ts
+++ b/backend/src/shared/api/types/PlayerSit.ts
@@ -4,6 +4,6 @@ export type PlayerSitPayload = {
 };
 
 export type PlayerSitOutput = {
-  ok: boolean,
-  error?: string
+  ok: boolean;
+  error?: string;
 };

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback } from 'react';
 import { Socket } from 'socket.io-client';
 
-import FetchFacade from '../../../fetch/FetchFacade';
-
-import { PlayerLeavePayload, PlayerLeaveOutput } from '../../../../../backend/src/shared/api/types/PlayerLeave';
 import apiCall from '../../../fetch/apiCall';
 
 type SeatProps = {
@@ -25,11 +22,10 @@ export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
 
   const playerLeave = useCallback(async (event: React.MouseEvent) => {
     const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
-    const result = await FetchFacade.post<PlayerLeavePayload, PlayerLeaveOutput>('tables.leave', payload);
-    if (result.ok) {
-      console.log(result.getValue());
-    } else {
-      console.log('error', result.errorMessage);
+    const result = await apiCall.post('tables.leave', payload);
+    if (!result?.ok) {
+      // Do something with the error
+      console.log(result?.error);
     }
   }, []);
 

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -5,6 +5,7 @@ import FetchFacade from '../../../fetch/FetchFacade';
 
 import { PlayerSitPayload, PlayerSitOutput } from '../../../../../backend/src/shared/api/types/PlayerSit';
 import { PlayerLeavePayload, PlayerLeaveOutput } from '../../../../../backend/src/shared/api/types/PlayerLeave';
+import apiCall from '../../../fetch/apiCall';
 
 type SeatProps = {
   seatNumber: string;
@@ -13,13 +14,13 @@ type SeatProps = {
 };
 
 export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
-  const playerSit = useCallback(async (event: React.MouseEvent) => {
+  const onPlayerSit = useCallback(async (event: React.MouseEvent) => {
     const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
-    const result = await FetchFacade.post<PlayerSitPayload, PlayerSitOutput>('/api/actions/tables.join', payload);
-    if (result.ok) {
-      console.log(result.getValue());
-    } else {
-      console.log('error', result.errorMessage);
+
+    const result = await apiCall.post('tables.join', payload);
+    if (!result?.ok) {
+      // Do something with the error
+      console.log(result?.error);
     }
   }, []);
 
@@ -39,6 +40,8 @@ export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
         Empty
       </div>
       <div onClick={playerLeave}> Leave Seat {seatNumber} </div>
+    <div className="seat" id={seatNumber} data-chip-count={chipCount} onClick={onPlayerSit}>
+      Empty
     </div>
   );
 }

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { Socket } from 'socket.io-client';
 
-import FetchFasade from '../../../fetch/FetchFasade';
+import FetchFacade from '../../../fetch/FetchFacade';
 
 import { PlayerSitPayload, PlayerSitOutput } from '../../../../../backend/src/shared/api/types/PlayerSit';
 import { PlayerLeavePayload, PlayerLeaveOutput } from '../../../../../backend/src/shared/api/types/PlayerLeave';
@@ -15,7 +15,7 @@ type SeatProps = {
 export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
   const playerSit = useCallback(async (event: React.MouseEvent) => {
     const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
-    const result = await FetchFasade.post<PlayerSitPayload, PlayerSitOutput>('/api/actions/tables.join', payload);
+    const result = await FetchFacade.post<PlayerSitPayload, PlayerSitOutput>('/api/actions/tables.join', payload);
     if (result.ok) {
       console.log(result.getValue());
     } else {

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -3,7 +3,6 @@ import { Socket } from 'socket.io-client';
 
 import FetchFacade from '../../../fetch/FetchFacade';
 
-import { PlayerSitPayload, PlayerSitOutput } from '../../../../../backend/src/shared/api/types/PlayerSit';
 import { PlayerLeavePayload, PlayerLeaveOutput } from '../../../../../backend/src/shared/api/types/PlayerLeave';
 import apiCall from '../../../fetch/apiCall';
 
@@ -26,7 +25,7 @@ export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
 
   const playerLeave = useCallback(async (event: React.MouseEvent) => {
     const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
-    const result = await FetchFasade.post<PlayerLeavePayload, PlayerLeaveOutput>('/api/actions/tables.leave', payload);
+    const result = await FetchFacade.post<PlayerLeavePayload, PlayerLeaveOutput>('tables.leave', payload);
     if (result.ok) {
       console.log(result.getValue());
     } else {
@@ -36,12 +35,10 @@ export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
 
   return (
     <div>
-      <div className="seat" id={seatNumber} data-chip-count={chipCount} onClick={playerSit}>
+      <button className="seat" id={seatNumber} data-chip-count={chipCount} onClick={onPlayerSit}>
         Empty
-      </div>
-      <div onClick={playerLeave}> Leave Seat {seatNumber} </div>
-    <div className="seat" id={seatNumber} data-chip-count={chipCount} onClick={onPlayerSit}>
-      Empty
+      </button>
+      <button onClick={playerLeave}>Leave Seat {seatNumber}</button>
     </div>
   );
 }

--- a/frontend/src/fetch/FetchFacade.ts
+++ b/frontend/src/fetch/FetchFacade.ts
@@ -18,7 +18,7 @@ class FetchFacade {
     headers.set('Content-Type', 'application/json');
     headers.set('Accept', 'application/json');
 
-    const request: RequestInfo = new Request('http://127.0.0.1:3000' + route, {
+    const request: RequestInfo = new Request('http://127.0.0.1:3000/api/actions/' + route, {
       method: 'POST',
       headers: headers,
       body: JSON.stringify(payload),
@@ -31,7 +31,7 @@ class FetchFacade {
     const headers: Headers = new Headers();
     headers.set('Accept', 'application/json');
 
-    const request: RequestInfo = new Request('http://127.0.0.1:3000' + route, {
+    const request: RequestInfo = new Request('http://127.0.0.1:3000/api/actions/' + route, {
       method: 'GET',
       headers: headers,
     });

--- a/frontend/src/fetch/FetchFacade.ts
+++ b/frontend/src/fetch/FetchFacade.ts
@@ -1,6 +1,6 @@
 import Result, { ResultSuccess, ResultError } from '../../../backend/src/shared/Result';
 
-class FetchFasade {
+class FetchFacade {
   private static async processRequest<TResult>(request: RequestInfo): Promise<Result<TResult>> {
     const response = await fetch(request);
 
@@ -24,7 +24,7 @@ class FetchFasade {
       body: JSON.stringify(payload),
     });
 
-    return FetchFasade.processRequest<TResult>(request);
+    return FetchFacade.processRequest<TResult>(request);
   }
 
   static async get<TResult>(route: string): Promise<Result<TResult>> {
@@ -36,8 +36,8 @@ class FetchFasade {
       headers: headers,
     });
 
-    return FetchFasade.processRequest<TResult>(request);
+    return FetchFacade.processRequest<TResult>(request);
   }
 }
 
-export default FetchFasade;
+export default FetchFacade;

--- a/frontend/src/fetch/apiCall.ts
+++ b/frontend/src/fetch/apiCall.ts
@@ -1,0 +1,24 @@
+import FetchFacade from './FetchFacade';
+
+import { ApiMethod, ApiMethodMap } from '../../../backend/src/shared/api/ApiMethodMap';
+
+const apiCall = {
+  async post<TMethod extends ApiMethod>(route: TMethod, payload: ApiMethodMap[TMethod]['request']) {
+    const result = await FetchFacade.post<ApiMethodMap[TMethod]['request'], ApiMethodMap[TMethod]['response']>(
+      route,
+      payload
+    );
+    if (result.ok) {
+      return result.getValue();
+    } else {
+      console.log(result.errorMessage);
+      throw new Error(result.errorMessage);
+    }
+  },
+
+  async get<TMethod extends ApiMethod>(route: TMethod) {
+    return await FetchFacade.get<ApiMethodMap[TMethod]['response']>(route);
+  },
+};
+
+export default apiCall;


### PR DESCRIPTION
### Description

- Refactored the api call logic to automatically take care of types when calling the api methods (now done via apiCall in front of FetchFacade)
- Simplified how an API is created. See: `ApiMethodMap.ts` and `routeConfig.ts`


### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->
[CU-86cue2ypy](https://app.clickup.com/t/86cue2ypy)


### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
