### PR TITLE
fix: change getAvailableSeats to return array instead of result

### DIFF
--- a/backend/src/game/PokerTable.test.ts
+++ b/backend/src/game/PokerTable.test.ts
@@ -98,35 +98,36 @@ describe('PokerTable', () => {
       GameLobbyService.createPokerTable(tableName, 2);
       jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => Result.success());
       const pokerTable = GameLobbyService.getTable(tableName);
-  
+
       if (!pokerTable) {
         // TODO: log error
         return;
       }
-      pokerTable.sitAtTable(tableName, 'seat-1', 'a1')
-      const res = pokerTable.leaveTable('seat-1', 'a1')
-  
+      pokerTable.sitAtTable(tableName, 'seat-1', 'a1');
+      const res = pokerTable.leaveTable('seat-1', 'a1');
+
       expect(res.ok).toEqual(true);
       expect(res.isError).toEqual(false);
       expect(res.errorMessage).toEqual('');
 
       const availableSeats = pokerTable.getAvailableSeats();
-      const seatExists: boolean = (availableSeats.value || []).some(seat => seat.seatNumber === 'seat-1');
-      expect(seatExists).toBe(true);
+
+      const seatExistsUpdated = availableSeats.some((seat) => seat.seatNumber === 'seat-1');
+      expect(seatExistsUpdated).toBe(true);
     });
-  
+
     it('should error when the player is not already sitting at the table', () => {
       const tableName = 'table_2';
       GameLobbyService.createPokerTable(tableName, 2);
       jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => Result.success());
       const pokerTable = GameLobbyService.getTable(tableName);
-  
+
       if (!pokerTable) {
         // TODO: log error
         return;
       }
-      const res = pokerTable.leaveTable('seat-1', 'b2')
-      
+      const res = pokerTable.leaveTable('seat-1', 'b2');
+
       expect(res.ok).toEqual(false);
       expect(res.isError).toEqual(true);
       expect(res.errorMessage).toEqual('Player not found on table');

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -69,27 +69,24 @@ export default class PokerTable {
 
   public leaveTable(seatNumber: string, clientId: string): Result<void> {
     for (const seat of this.seats) {
-        if (seat.playerId == clientId ){
-          seat.playerId = '';
-          seat.isTaken = false;
-          return Result.success();
-        }
+      if (seat.playerId == clientId) {
+        seat.playerId = '';
+        seat.isTaken = false;
+        return Result.success();
+      }
     }
     return Result.error('Player not found on table');
   }
 
-  public getAvailableSeats(): Result<Seat[]> {
+  public getAvailableSeats(): Seat[] {
     const availableSeats = [];
+
     for (const seat of this.seats) {
-      if (seat.isTaken == false) {
+      if (seat.isTaken === false) {
         availableSeats.push(seat);
       }
     }
-    if (availableSeats.length > 0) {
-      return new ResultSuccess(availableSeats);
-    } else {
-      return new ResultError('No seats available');
-    }
+    return availableSeats;
   }
 
   getName() {


### PR DESCRIPTION
### Preface
I isolated this change from the original PR as a learning exercise around error handling and Test Driven Development so that we can reference it if we need

### Description of changes
Change `getAvailableSeats` to return an array of seats instead of a `Result<Seats[]>` 

### Why?
We added the [getAvailableSeats](https://github.com/richardaspinall/poker-react-node/blob/8493645c340b7083474b8004d358513a79c72489/backend/src/game/PokerTable.ts#L81) function to return all available seats at the table. We don't need to return an error here because an empty array is an expected state the caller could expect / "there are no available seats"

### When would we error:
Say that for some reason we only use this function when we know there are available seats (so we expect at least 1 seat is available), then we would want to return an error that there are no seats. 

### TDD steps
1. In the tests we originally had a result containing an array (or undefined), I simply updated it to do the check on an array
2. Ran the tests and checked that they now fail
3. Updated  `getAvailableSeats()` return type to an array of seats, and then removed the checks and creation of a result, simply returning the array 

### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )

[CU-86cueaam8 ](https://app.clickup.com/t/86cueaam8)
--->

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task


<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
