### PR TITLE
feat: api payload validation (part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ https://www.npmjs.com/package/debug
 
 `NAMESPACE=APP:Sockets npm run start:debug-only` displays only logs in the sockets namespace (`APP:Sockets`)
 
+`DEBUG=APP:* npm run api_tests` shows debug logs when running tests
+
 ### Generic info, error and debugging:
 
 Note: better to use the above namespacing for more specific logging

--- a/backend/README.md
+++ b/backend/README.md
@@ -40,7 +40,8 @@ Extension: humao.rest-client
     "dotenv": "^16.3.1", // allow for environment variables in .env file
     "express": "^4.18.2", // server framework
     "mysql2": "^3.6.5", // for working with mysql
-    "socket.io": "^4.7.2" // socket library
+    "socket.io": "^4.7.2", // socket library
+    "joi": "^17.12.1", // schema validation
   },
   "devDependencies": {
     // types for each library:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "joi": "^17.12.1",
         "mysql2": "^3.6.5",
         "socket.io": "^4.7.2"
       },
@@ -687,6 +688,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1177,6 +1191,24 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4050,6 +4082,18 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6255,6 +6299,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -6637,6 +6694,24 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -8852,6 +8927,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "joi": "^17.12.1",
     "mysql2": "^3.6.5",
     "socket.io": "^4.7.2"
   },

--- a/backend/src/game-lobby-service/index.ts
+++ b/backend/src/game-lobby-service/index.ts
@@ -1,5 +1,6 @@
 import GameLobbyService from './GameLobbyService';
 // Seed for now
 const gameLobbyService = new GameLobbyService();
+console.log('here');
 gameLobbyService.createPokerTable('table_1', 2);
 export default gameLobbyService;

--- a/backend/src/game-lobby-service/index.ts
+++ b/backend/src/game-lobby-service/index.ts
@@ -1,5 +1,6 @@
 import GameLobbyService from './GameLobbyService';
-// Seed for now
+
+// TODO: Seed / hardcode for now until we are working with a DB
 const gameLobbyService = new GameLobbyService();
 console.log('here');
 gameLobbyService.createPokerTable('table_1', 2);

--- a/backend/src/game-lobby-service/index.ts
+++ b/backend/src/game-lobby-service/index.ts
@@ -2,6 +2,5 @@ import GameLobbyService from './GameLobbyService';
 
 // TODO: Seed / hardcode for now until we are working with a DB
 const gameLobbyService = new GameLobbyService();
-console.log('here');
 gameLobbyService.createPokerTable('table_1', 2);
 export default gameLobbyService;

--- a/backend/src/handlers/actions/TablesJoinHandler.test.ts
+++ b/backend/src/handlers/actions/TablesJoinHandler.test.ts
@@ -20,6 +20,22 @@ import GameLobbyService from '../../game-lobby-service';
 const debug = Logger.newDebugger('test:tables');
 
 describe('tables.join', () => {
+  // TODO: need to add more unit tests for invalid requests and types
+  it('should error when payload is invalid', async () => {
+    jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
+    jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
+    GameLobbyService.createPokerTable('table_1', 2);
+
+    const res = await request(httpServer).post('/api/actions/tables.join').send({
+      selectedSeatNumber: 1,
+      socketId: 'abc123',
+    });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.ok).toEqual(false);
+    expect(res.body.error).toEqual('Invalid request payload');
+  });
+
   // TODO: will eventually need to add the table they are sitting at but this is hardcoded
   // for now. See third commented out test
   it('should seat a player to a table', async () => {
@@ -49,21 +65,6 @@ describe('tables.join', () => {
     expect(res.statusCode).toEqual(200);
     expect(res.body.ok).toEqual(false);
     expect(res.body.error).toEqual('Seat is already taken');
-  });
-
-  // TODO: need to add more unit tests for invalid requests and types
-  it('should error when payload is invalid', async () => {
-    jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
-    jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
-    GameLobbyService.createPokerTable('table_1', 2);
-    const res = await request(httpServer).post('/api/actions/tables.join').send({
-      selectedSeatNumber: 1,
-      socketId: 'abc123',
-    });
-
-    expect(res.statusCode).toEqual(400);
-    expect(res.body.ok).toEqual(false);
-    expect(res.body.error).toEqual('Invalid request payload');
   });
 
   // it('should error when the table doesnt exist', async () => {

--- a/backend/src/handlers/actions/TablesJoinHandler.test.ts
+++ b/backend/src/handlers/actions/TablesJoinHandler.test.ts
@@ -51,6 +51,21 @@ describe('tables.join', () => {
     expect(res.body.error).toEqual('Seat is already taken');
   });
 
+  // TODO: need to add more unit tests for invalid requests and types
+  it('should error when payload is invalid', async () => {
+    jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
+    jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
+    GameLobbyService.createPokerTable('table_1', 2);
+    const res = await request(httpServer).post('/api/actions/tables.join').send({
+      selectedSeatNumber: 1,
+      socketId: 'abc123',
+    });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.ok).toEqual(false);
+    expect(res.body.error).toEqual('Invalid request payload');
+  });
+
   // it('should error when the table doesnt exist', async () => {
   //   mockSendEventToRoomError();
   //   const res = await request(httpServer).post('/api/actions/tables.join').send({

--- a/backend/src/handlers/actions/TablesLeaveHandler.test.ts
+++ b/backend/src/handlers/actions/TablesLeaveHandler.test.ts
@@ -20,6 +20,22 @@ import Result, { ResultSuccess, ResultError } from '../../shared/Result';
 const debug = Logger.newDebugger('test:tables');
 
 describe('tables.leave', () => {
+  // TODO: need to add more unit tests for invalid requests and types
+  it('should error when payload is invalid', async () => {
+    jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
+    jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError('Room not found'));
+    GameLobbyService.createPokerTable('table_1', 2);
+
+    const res = await request(httpServer).post('/api/actions/tables.leave').send({
+      selectedSeatNumber: 1,
+      socketId: 'abc123',
+    });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.ok).toEqual(false);
+    expect(res.body.error).toEqual('Invalid request payload');
+  });
+
   // TODO: will eventually need to add the table they are sitting at but this is hardcoded
   // for now. See third commented out test
   it('should remove a player from a table', async () => {

--- a/backend/src/shared/Result.ts
+++ b/backend/src/shared/Result.ts
@@ -3,6 +3,7 @@ export default class Result<T> {
     public ok: boolean,
     public isError: boolean,
     public errorMessage: string = '',
+    public errorDetails: any = {},
     public value: T | undefined = undefined
   ) {}
 
@@ -22,8 +23,8 @@ export default class Result<T> {
 }
 
 export class ResultError<T> extends Result<T> {
-  constructor(public errorMessage: string) {
-    super(false, true, errorMessage);
+  constructor(public errorMessage: string, public errorDetails: any = {}) {
+    super(false, true, errorMessage, errorDetails);
   }
 }
 

--- a/backend/src/shared/api/types/PlayerLeave.ts
+++ b/backend/src/shared/api/types/PlayerLeave.ts
@@ -1,10 +1,42 @@
+// External
+import Joi from 'joi';
+
+// Internal
+import Result, { ResultError, ResultSuccess } from '../../Result';
+
+// Internal utils
+import Logger from '../../../utils/Logger';
+
+const debug = Logger.newDebugger('APP:Validation');
+
 export type PlayerLeavePayload = {
-    selectedSeatNumber: string;
-    socketId: string;
-  };
-  
-  export type PlayerLeaveOutput = {
-    ok: boolean,
-    error?: string
-  };
-  
+  selectedSeatNumber: string;
+  socketId: string;
+};
+
+export type PlayerLeaveOutput = {
+  ok: boolean;
+  error?: string;
+  error_details?: string;
+};
+
+// Joi schema
+export const tableLeaveSchema = Joi.object({
+  selectedSeatNumber: Joi.string().required(),
+  socketId: Joi.string().required(),
+});
+
+export function validateTableLeavePayload(payload: any): Result<PlayerLeavePayload> {
+  // Runtime validation with Joi
+  const { error, value } = tableLeaveSchema.validate(payload, { abortEarly: false });
+
+  if (error) {
+    debug(error.details);
+    return new ResultError('Invalid request payload', error.details);
+  }
+  // Here, 'value' is validated by Joi, but TypeScript doesn't know its type.
+  // You can use type assertion to inform TypeScript about the type.
+  const res: PlayerLeavePayload = value;
+
+  return new ResultSuccess(res);
+}

--- a/backend/src/shared/api/types/PlayerSit.ts
+++ b/backend/src/shared/api/types/PlayerSit.ts
@@ -1,6 +1,14 @@
+// External
 import Joi from 'joi';
 
+// Internal
+
 import Result, { ResultError, ResultSuccess } from '../../Result';
+
+// Internal utils
+import Logger from '../../../utils/Logger';
+
+const debug = Logger.newDebugger('APP:Validation');
 
 export type PlayerSitPayload = {
   selectedSeatNumber: string;
@@ -14,17 +22,17 @@ export type PlayerSitOutput = {
 };
 
 // Joi schema
-export const tableCreateSchema = Joi.object({
+export const tableJoinSchema = Joi.object({
   selectedSeatNumber: Joi.string().required(),
   socketId: Joi.string().required(),
 });
 
 export function validatePlayerSitPayload(payload: any): Result<PlayerSitPayload> {
   // Runtime validation with Joi
-  const { error, value } = tableCreateSchema.validate(payload, { abortEarly: false });
+  const { error, value } = tableJoinSchema.validate(payload, { abortEarly: false });
 
   if (error) {
-    console.log(error.details);
+    debug(error.details);
     return new ResultError('Invalid request payload', error.details);
   }
   // Here, 'value' is validated by Joi, but TypeScript doesn't know its type.

--- a/backend/src/shared/api/types/PlayerSit.ts
+++ b/backend/src/shared/api/types/PlayerSit.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
+import Result, { ResultError, ResultSuccess } from '../../Result';
+
 export type PlayerSitPayload = {
   selectedSeatNumber: string;
   socketId: string;
@@ -7,3 +11,24 @@ export type PlayerSitOutput = {
   ok: boolean;
   error?: string;
 };
+
+// Joi schema
+export const tableCreateSchema = Joi.object({
+  selectedSeatNumber: Joi.string().required(),
+  socketId: Joi.string().required(),
+});
+
+export function validateTableCreatePayload(payload: any): Result<PlayerSitPayload> {
+  // Runtime validation with Joi
+  const { error, value } = tableCreateSchema.validate(payload, { abortEarly: false });
+
+  if (error) {
+    console.log(error.details);
+    return new ResultError('Invalid request payload', error.details);
+  }
+  // Here, 'value' is validated by Joi, but TypeScript doesn't know its type.
+  // You can use type assertion to inform TypeScript about the type.
+  const res: PlayerSitPayload = value;
+
+  return new ResultSuccess(res);
+}

--- a/backend/src/shared/api/types/PlayerSit.ts
+++ b/backend/src/shared/api/types/PlayerSit.ts
@@ -10,6 +10,7 @@ export type PlayerSitPayload = {
 export type PlayerSitOutput = {
   ok: boolean;
   error?: string;
+  error_details?: string;
 };
 
 // Joi schema
@@ -18,7 +19,7 @@ export const tableCreateSchema = Joi.object({
   socketId: Joi.string().required(),
 });
 
-export function validateTableCreatePayload(payload: any): Result<PlayerSitPayload> {
+export function validatePlayerSitPayload(payload: any): Result<PlayerSitPayload> {
   // Runtime validation with Joi
   const { error, value } = tableCreateSchema.validate(payload, { abortEarly: false });
 

--- a/backend/test-requests/tablesJoin.http
+++ b/backend/test-requests/tablesJoin.http
@@ -2,16 +2,10 @@
 # With the REST Client extension in vscode, the below requests will show an option 
 # to send the request as a curl command. 
 
-###
-GET http://localhost:3000/api/actions
-
-###
-
-POST http://localhost:3000/api/actions
+POST http://localhost:3000/api/actions/tables.join
 content-type: application/json
 
 {
-    "test": "Hello world",
-    "time": "Wed, 21 Oct 2015 18:27:50 GMT"
+    "selectedSeatNumber": "seat-1",
+    "socketId": "abc123"
 }
-

--- a/backend/test-requests/tablesJoin.http
+++ b/backend/test-requests/tablesJoin.http
@@ -2,10 +2,22 @@
 # With the REST Client extension in vscode, the below requests will show an option 
 # to send the request as a curl command. 
 
+### should pass:
+
 POST http://localhost:3000/api/actions/tables.join
 content-type: application/json
 
 {
     "selectedSeatNumber": "seat-1",
+    "socketId": "abc123"
+}
+
+### should error with Invalid request payload and error_details:
+
+POST http://localhost:3000/api/actions/tables.join
+content-type: application/json
+
+{
+    "selectedSeatNumber": 1234,
     "socketId": "abc123"
 }

--- a/backend/test-requests/tablesLeave.http
+++ b/backend/test-requests/tablesLeave.http
@@ -6,6 +6,6 @@ POST http://localhost:3000/api/actions/tables.leave
 content-type: application/json
 
 {
-    "test": "Hello world",
-    "time": "Wed, 21 Oct 2015 18:27:50 GMT"
+    "selectedSeatNumber": "seat-1",
+    "socketId": "abc123"
 }

--- a/backend/test-requests/tablesLeave.http
+++ b/backend/test-requests/tablesLeave.http
@@ -2,16 +2,10 @@
 # With the REST Client extension in vscode, the below requests will show an option 
 # to send the request as a curl command. 
 
-###
-GET http://localhost:3000/api/actions
-
-###
-
-POST http://localhost:3000/api/actions
+POST http://localhost:3000/api/actions/tables.leave
 content-type: application/json
 
 {
     "test": "Hello world",
     "time": "Wed, 21 Oct 2015 18:27:50 GMT"
 }
-


### PR DESCRIPTION
### Description
This is part 1 of API Payload Validation (make it work and fail fast)

See here for part 2: https://github.com/richardaspinall/poker-react-node/pull/48

--- 

- This PR adds payload validation (via JOI) for end points. 
- Test requests

Fast follows:
- V2 validation (further refactor)
- Documentation ([CU-86cu9tkhw](https://app.clickup.com/t/86cu9tkhw)) 

### How to test

<!--- Steps on how to test this change  --->

1. Within VS code install [REST client extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
2. Start the app with debug enabled for validation `DEBUG=App:Validation npm run start:dev`
3. Head to backend/test-requests and submit the `tablesJoin.http` and `tablesLeave.http` requests
4. Change the payload in the requests to different combinations of errors (including invalid payloads like numbers instead of strings)
5. Note the responses when payloads are correct or incorrect

<img width="617" alt="Screenshot 2024-02-14 at 9 51 10 am" src="https://github.com/richardaspinall/poker-react-node/assets/15721687/9cfe6fc1-77f6-4e6d-8f8f-f6d3456e77d0">


### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->

[CU-86cu3hfa9](https://app.clickup.com/t/86cu3hfa9) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added unit tests
- [x] Added learning objectives to clickup task
- [x] Added new package information to appropriate README

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
