### PR TITLE
fix: check seat number when leaving table

### DIFF
--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -71,7 +71,7 @@ export class PokerTable {
 
   public leaveTable(seatNumber: string, clientId: string): Result<void> {
     for (const seat of this.seats) {
-      if (seat.playerId == clientId) {
+      if (seat.playerId === clientId && seat.seatNumber === seatNumber) {
         seat.playerId = '';
         seat.isTaken = false;
         return Result.success();


### PR DESCRIPTION
### Description

We weren't checking the seat number in the table leave logic so it allowed us to send empty seat numbers which now breaks due to the API validation work!

### Task

CU-[86cughgpk](https://app.clickup.com/t/86cughgpk)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task
