### PR TITLE
fix: send seat number when leaving table

### DIFF
--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -10,24 +10,24 @@ type SeatProps = {
 };
 
 export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
-  const onPlayerSit = useCallback(async (event: React.MouseEvent) => {
-    const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
+  const onPlayerSit = useCallback(async () => {
+    const payload = { selectedSeatNumber: seatNumber, socketId: socket.id };
 
     const result = await apiCall.post('tables.join', payload);
     if (!result?.ok) {
       // Do something with the error
       console.log(result?.error);
     }
-  }, []);
+  }, [seatNumber, socket]);
 
-  const playerLeave = useCallback(async (event: React.MouseEvent) => {
-    const payload = { selectedSeatNumber: event.currentTarget.id, socketId: socket.id };
+  const playerLeave = useCallback(async () => {
+    const payload = { selectedSeatNumber: seatNumber, socketId: socket.id };
     const result = await apiCall.post('tables.leave', payload);
     if (!result?.ok) {
       // Do something with the error
       console.log(result?.error);
     }
-  }, []);
+  }, [seatNumber, socket]);
 
   return (
     <div>


### PR DESCRIPTION
### Description

We weren't sending the required seat number when leaving a seat, this was a bug / false positive on the backend but has been fixed as per: https://github.com/richardaspinall/poker-react-node/pull/57

### How to test

<!--- Steps on how to test this change  --->

1. Open the game
2. Click on a seat to sit
3. Click on Leave Seat

### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->

[CU-86cuquqj8 ](https://app.clickup.com/t/86cuquqj8)

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
