### PR TITLE
refactor: change players table name to users

### DIFF
--- a/backend/db/MySql/MySql.test.ts
+++ b/backend/db/MySql/MySql.test.ts
@@ -4,16 +4,16 @@ describe('MySql', () => {
   const mySql = new MySql(process.env.DB_DATABASE || '');
 
   describe('select', () => {
-    it('should select player 1000', async () => {
-      const [player] = await mySql.select('SELECT * FROM players WHERE player_id = ?', [1000]);
+    it('should select user 1000', async () => {
+      const [player] = await mySql.select('SELECT * FROM users WHERE user_id = ?', [1000]);
 
-      expect(player).toEqual({ password: 'testpassword', player_id: 1000, username: 'raspinall' });
+      expect(player).toEqual({ password: 'testpassword', user_id: 1000, username: 'raspinall' });
     });
   });
 
   describe('insert', () => {
-    it('should insert a new player', async () => {
-      const result = await mySql.insert('INSERT INTO players (username, password) VALUES (?, ?)', [
+    it('should insert a new user', async () => {
+      const result = await mySql.insert('INSERT INTO users (username, password) VALUES (?, ?)', [
         'james',
         'testpassword',
       ]);
@@ -22,7 +22,7 @@ describe('MySql', () => {
     });
 
     it('should return a duplicate entry error when entering a used username', async () => {
-      const result = await mySql.insert('INSERT INTO players (username, password) VALUES (?, ?)', [
+      const result = await mySql.insert('INSERT INTO users (username, password) VALUES (?, ?)', [
         'james',
         'testpassword',
       ]);
@@ -32,8 +32,8 @@ describe('MySql', () => {
   });
 
   describe('delete', () => {
-    it('should delete a player', async () => {
-      const result = await mySql.delete('DELETE FROM players WHERE username = ?', ['james']);
+    it('should delete a user', async () => {
+      const result = await mySql.delete('DELETE FROM users WHERE username = ?', ['james']);
 
       expect(result.affectedRows).toEqual(1);
     });

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -1,19 +1,20 @@
-CREATE TABLE players (
-  player_id INT unsigned NOT NULL AUTO_INCREMENT,
+CREATE TABLE users (
+  user_id INT unsigned NOT NULL AUTO_INCREMENT,
   username VARCHAR(20) NOT NULL UNIQUE,
   password CHAR(60) NOT NULL,
-  PRIMARY KEY (player_id)
+  PRIMARY KEY (user_id)
 );
+
 CREATE TABLE poker_tables (
   poker_table_id INT unsigned NOT NULL AUTO_INCREMENT,
   poker_table_name VARCHAR(20) NOT NULL UNIQUE,
   PRIMARY KEY (poker_table_id)
 );
-CREATE TABLE poker_table_players (
+CREATE TABLE poker_table_users (
   poker_table_id INT unsigned NOT NULL,
-  player_id INT unsigned NOT NULL,
-  PRIMARY KEY (poker_table_id, player_id),
+  user_id INT unsigned NOT NULL,
+  PRIMARY KEY (poker_table_id, user_id),
   FOREIGN KEY (poker_table_id) REFERENCES poker_tables(poker_table_id),
-  FOREIGN KEY (player_id) REFERENCES players(player_id)
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
 );
-ALTER TABLE players AUTO_INCREMENT = 1000;
+ALTER TABLE users AUTO_INCREMENT = 1000;

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -1,4 +1,4 @@
-INSERT INTO players
+INSERT INTO users
 (username, password)
 VALUES 
 ('raspinall', 'testpassword'),
@@ -10,8 +10,8 @@ VALUES
 ('table_1'),
 ('table_2');
 
-INSERT INTO poker_table_players
-(poker_table_id, player_id)
+INSERT INTO poker_table_users
+(poker_table_id, user_id)
 VALUES
 (1, 1000),
 (1, 1001),


### PR DESCRIPTION
### Description

Simply changing the table name from players to users as a "player" as a concept by itself won't be in the DB (for now). We just want to create users and then the player is created in memory.

### How to test

`cd backend && npm run db_tests`

### Task

[CU-86cut0du3 ](https://app.clickup.com/t/86cut0du3)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added unit tests

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
