### PR TITLE
refactor: make mysql generic

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "db_tests": "DB_DATABASE=dev_poker jest --config jest.config.db.js",
     "api_tests": "jest --config jest.config.api.js --runInBand",
     "dev": "nodemon",
-    "create-test-db": "DB=test_poker node db/create_dev_db.js",
+    "create-test-db": "DB_DATABASE=test_poker node src/db/create_dev_db.js",
     "lint": "eslint . --ext .ts"
   },
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "unit_tests": "jest $npm_config_file",
-    "db_tests": "DB_DATABASE=dev_poker jest --config jest.config.db.js",
+    "db_tests": "DB_DATABASE=test_poker jest --config jest.config.db.js",
     "api_tests": "jest --config jest.config.api.js --runInBand",
     "dev": "nodemon",
     "create-test-db": "DB_DATABASE=test_poker node src/db/create_dev_db.js",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "unit_tests": "jest $npm_config_file",
-    "db_tests": "DB=test_poker jest --config jest.config.db.js",
+    "db_tests": "DB_DATABASE=dev_poker jest --config jest.config.db.js",
     "api_tests": "jest --config jest.config.api.js --runInBand",
     "dev": "nodemon",
     "create-test-db": "DB=test_poker node db/create_dev_db.js",

--- a/backend/src/db/MySql/MySql.test.ts
+++ b/backend/src/db/MySql/MySql.test.ts
@@ -36,7 +36,7 @@ describe('MySql', () => {
     it('should delete a user', async () => {
       const result = await mySql.delete('DELETE FROM users WHERE username = ?', ['james']);
 
-      expect(result.affectedRows).toEqual(1);
+      expect(result.isOk()).toEqual(true);
     });
   });
 

--- a/backend/src/db/MySql/MySql.test.ts
+++ b/backend/src/db/MySql/MySql.test.ts
@@ -19,7 +19,7 @@ describe('MySql', () => {
         'james',
         'testpassword',
       ]);
-      expect(result.isOk()).toEqual(true);
+      expect(result.ok).toEqual(true);
     });
 
     it('should return a duplicate entry error when entering a used username', async () => {
@@ -36,7 +36,7 @@ describe('MySql', () => {
     it('should delete a user', async () => {
       const result = await mySql.delete('DELETE FROM users WHERE username = ?', ['james']);
 
-      expect(result.isOk()).toEqual(true);
+      expect(result.ok).toEqual(true);
     });
   });
 

--- a/backend/src/db/MySql/MySql.test.ts
+++ b/backend/src/db/MySql/MySql.test.ts
@@ -14,13 +14,12 @@ describe('MySql', () => {
   });
 
   describe('insert', () => {
-    it('should insert a new user', async () => {
+    it('should insert a new player', async () => {
       const result = await mySql.insert('INSERT INTO users (username, password) VALUES (?, ?)', [
         'james',
         'testpassword',
       ]);
-
-      expect(result.affectedRows).toEqual(1);
+      expect(result.isOk()).toEqual(true);
     });
 
     it('should return a duplicate entry error when entering a used username', async () => {
@@ -29,7 +28,7 @@ describe('MySql', () => {
         'testpassword',
       ]);
 
-      expect(result.code).toEqual('ER_DUP_ENTRY');
+      expect(result.error?.code).toEqual('DUPLICATE_ENTRY');
     });
   });
 

--- a/backend/src/db/MySql/MySql.test.ts
+++ b/backend/src/db/MySql/MySql.test.ts
@@ -5,7 +5,7 @@ describe('MySql', () => {
 
   describe('select', () => {
     it('should select player 1000', async () => {
-      const resRows = await mySql.select('SELECT * FROM users WHERE user_id = ?', [1000]);
+      const resRows = await mySql.select('users', ['user_id'], [1000]);
 
       resRows.getValue().forEach((row) => {
         expect(row).toEqual({ password: 'testpassword', user_id: 1000, username: 'raspinall' });
@@ -15,18 +15,13 @@ describe('MySql', () => {
 
   describe('insert', () => {
     it('should insert a new player', async () => {
-      const result = await mySql.insert('INSERT INTO users (username, password) VALUES (?, ?)', [
-        'james',
-        'testpassword',
-      ]);
+      const result = await mySql.insert('users', ['username', 'password'], ['james', 'testpassword']);
+
       expect(result.ok).toEqual(true);
     });
 
     it('should return a duplicate entry error when entering a used username', async () => {
-      const result = await mySql.insert('INSERT INTO users (username, password) VALUES (?, ?)', [
-        'james',
-        'testpassword',
-      ]);
+      const result = await mySql.insert('users', ['username', 'password'], ['james', 'testpassword']);
 
       expect(result.error?.code).toEqual('DUPLICATE_ENTRY');
     });
@@ -34,7 +29,7 @@ describe('MySql', () => {
 
   describe('delete', () => {
     it('should delete a user', async () => {
-      const result = await mySql.delete('DELETE FROM users WHERE username = ?', ['james']);
+      const result = await mySql.delete('users', ['username'], ['james']);
 
       expect(result.ok).toEqual(true);
     });

--- a/backend/src/db/MySql/MySql.test.ts
+++ b/backend/src/db/MySql/MySql.test.ts
@@ -4,10 +4,12 @@ describe('MySql', () => {
   const mySql = new MySql(process.env.DB_DATABASE || '');
 
   describe('select', () => {
-    it('should select user 1000', async () => {
-      const [player] = await mySql.select('SELECT * FROM users WHERE user_id = ?', [1000]);
+    it('should select player 1000', async () => {
+      const resRows = await mySql.select('SELECT * FROM users WHERE user_id = ?', [1000]);
 
-      expect(player).toEqual({ password: 'testpassword', user_id: 1000, username: 'raspinall' });
+      resRows.getValue().forEach((row) => {
+        expect(row).toEqual({ password: 'testpassword', user_id: 1000, username: 'raspinall' });
+      });
     });
   });
 

--- a/backend/src/db/MySql/MySql.ts
+++ b/backend/src/db/MySql/MySql.ts
@@ -1,6 +1,12 @@
 require('dotenv').config();
 
-import { createPool, Pool } from 'mysql2/promise';
+// External
+import { createPool, Pool, RowDataPacket } from 'mysql2/promise';
+
+// Internal
+import { Result, ResultError, ResultSuccess } from '@shared/Result';
+import { DBSelectError } from '@shared/errors/DB/DBSelectErrors';
+import { DBInsertError, DBInsertDuplicateError } from '@shared/errors/DB/DBInsertErrors';
 
 class MySql {
   private pool: Pool;
@@ -18,12 +24,13 @@ class MySql {
   // TODO: Should prefix the queries with the query types
   // e.g. select, insert, update, delete
   // then the params should be the table and the where clauses
-  async select(query: string, params: any[] = []): Promise<any> {
+  async select(query: string, params: any[] = []): Promise<Result<RowDataPacket[]>> {
     try {
-      const [rows] = await this.pool.execute(query, params);
-      return rows;
+      const [rows] = await this.pool.execute<RowDataPacket[]>(query, params);
+      return new ResultSuccess(rows);
     } catch (error) {
-      return error;
+      // const mysqlError = error as Error & { code?: string };
+      return new ResultError(new DBSelectError('players'));
     }
   }
 

--- a/backend/src/db/MySql/MySql.ts
+++ b/backend/src/db/MySql/MySql.ts
@@ -7,6 +7,7 @@ import { createPool, Pool, RowDataPacket } from 'mysql2/promise';
 import { Result, ResultError, ResultSuccess } from '@shared/Result';
 import { DBSelectError } from '@shared/errors/DB/DBSelectErrors';
 import { DBInsertError, DBInsertDuplicateError } from '@shared/errors/DB/DBInsertErrors';
+import { DBDeleteError } from '@shared/errors/DB/DBDeleteErrors';
 
 class MySql {
   private pool: Pool;
@@ -49,12 +50,13 @@ class MySql {
     }
   }
 
-  async delete(query: string, params: any[] = []): Promise<any> {
+  async delete(query: string, params: any[] = []): Promise<Result<void>> {
     try {
       const [result] = await this.pool.execute(query, params);
-      return result;
+      return Result.success();
     } catch (error) {
-      return error;
+      console.log(error);
+      return Result.error(new DBDeleteError('users'));
     }
   }
 

--- a/backend/src/db/MySql/MySql.ts
+++ b/backend/src/db/MySql/MySql.ts
@@ -30,16 +30,22 @@ class MySql {
       return new ResultSuccess(rows);
     } catch (error) {
       // const mysqlError = error as Error & { code?: string };
-      return new ResultError(new DBSelectError('players'));
+      return new ResultError(new DBSelectError('users'));
     }
   }
 
-  async insert(query: string, params: any[] = []): Promise<any> {
+  async insert(query: string, params: any[] = []): Promise<Result<void>> {
     try {
-      const [result] = await this.pool.execute(query, params);
-      return result;
+      const [result] = await this.pool.execute<RowDataPacket[]>(query, params);
+      return Result.success();
     } catch (error) {
-      return error;
+      const mysqlError = error as Error & { code?: string };
+      if (mysqlError.code === 'ER_DUP_ENTRY') {
+        // TODO: add the actual table from the query
+        return Result.error(new DBInsertDuplicateError('users'));
+      } else {
+        return Result.error(new DBInsertError('users'));
+      }
     }
   }
 

--- a/backend/src/db/MySql/MySql.ts
+++ b/backend/src/db/MySql/MySql.ts
@@ -9,6 +9,9 @@ import { DBSelectError } from '@shared/errors/DB/DBSelectErrors';
 import { DBInsertError, DBInsertDuplicateError } from '@shared/errors/DB/DBInsertErrors';
 import { DBDeleteError } from '@shared/errors/DB/DBDeleteErrors';
 
+/**
+ * MySql is responsible for managing the connection to the database and executing queries.
+ */
 class MySql {
   private pool: Pool;
 
@@ -22,9 +25,6 @@ class MySql {
     });
   }
 
-  // TODO: Should prefix the queries with the query types
-  // e.g. select, insert, update, delete
-  // then the params should be the table and the where clauses
   async select(table: string, whereClause: string[] = [], params: any[] = []): Promise<Result<RowDataPacket[]>> {
     const where =
       whereClause.length > 0 ? `WHERE ${whereClause.map((condition) => `${condition} = ?`).join(' AND ')}` : '';

--- a/backend/src/shared/Result.ts
+++ b/backend/src/shared/Result.ts
@@ -4,6 +4,10 @@
 export class Result<T> {
   constructor(public ok: boolean, public value: T | undefined = undefined, public error?: BaseError) {}
 
+  public isOk(): boolean {
+    return this.ok;
+  }
+
   public getValue(): T {
     if (this.error) throw new Error(this.error.code);
     if (!this.value) throw new Error('Value is undefined');

--- a/backend/src/shared/Result.ts
+++ b/backend/src/shared/Result.ts
@@ -4,10 +4,6 @@
 export class Result<T> {
   constructor(public ok: boolean, public value: T | undefined = undefined, public error?: BaseError) {}
 
-  public isOk(): boolean {
-    return this.ok;
-  }
-
   public getValue(): T {
     if (this.error) throw new Error(this.error.code);
     if (!this.value) throw new Error('Value is undefined');

--- a/backend/src/shared/errors/DB/DBDeleteErrors.ts
+++ b/backend/src/shared/errors/DB/DBDeleteErrors.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@shared/Result';
+
+export class DBDeleteError extends BaseError {
+  constructor(public tableName: string) {
+    super('DELETION_FAILED', `Deletion failed to: ${tableName}`);
+  }
+}

--- a/backend/src/shared/errors/DB/DBInsertErrors.ts
+++ b/backend/src/shared/errors/DB/DBInsertErrors.ts
@@ -1,0 +1,13 @@
+import { BaseError } from '@shared/Result';
+
+export class DBInsertError extends BaseError {
+  constructor(public tableName: string) {
+    super('INSERTION_FAILED', `Insertion failed to: ${tableName}`);
+  }
+}
+
+export class DBInsertDuplicateError extends BaseError {
+  constructor(public tableName: string) {
+    super('DUPLICATE_ENTRY', `Insertion failed to: ${tableName} because of duplicate entry`);
+  }
+}

--- a/backend/src/shared/errors/DB/DBSelectErrors.ts
+++ b/backend/src/shared/errors/DB/DBSelectErrors.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@shared/Result';
+
+export class DBSelectError extends BaseError {
+  constructor(public tableName: string) {
+    super('SELECT_FAILED', `Selection failed to: ${tableName}`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "api_tests": "cd backend && npm run api_tests",
     "start:dev-frontend": "cd frontend && npm run dev",
     "start:dev-backend": "cd backend && npm run dev",
-    "create-dev-db": "cd backend && DB=dev_poker node db/create_dev_db.js"
+    "create-dev-db": "cd backend && DB_DATABASE=dev_poker node src/db/create_dev_db.js"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",


### PR DESCRIPTION
### Description

This PR updates the MySql class to accept parameters for the table and query and adds the type for the return.

### How to test

`cd backend && npm run db_tests`

### Task

[CU-86cucf0tx](https://app.clickup.com/t/86cucf0tx) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Updated unit tests
- [x] Added comments
- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
