### PR TITLE
docs: add style guide

### DIFF
--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -1,0 +1,19 @@
+# Style guide
+
+## Import order
+
+1. Standard Library Imports
+   - `import path from 'path';`
+   - `import fs from 'fs';`
+2. External Library Imports
+   - `import express from 'express';`
+   - `import Joi from 'joi';`
+3. Framework and Uitility Imports
+   - `import React from 'react';`
+   - `import lodash from 'lodash';`
+4. Alias Imports
+   - `import { BaseError } from '@infra/BaseError';`
+   - `import { shutDownServer } from '@tests/helpers/shutDownServer';;`
+5. RelativeImports
+   - `import { MyComponent } from './components/MyComponent';`
+   - `import { myHelperFunction } from '../helpers/myHelperFunction';`


### PR DESCRIPTION
### Description
This is just a starter for a code style guide:

Changing from commenting "internal / external" to an order of imports as per the readme. 

As we modify and add code, we should update the import order to be somewhat consistent (doesn't need to be perfect)

### Task

[CU-86cuyr7nt](https://app.clickup.com/t/86cuyr7nt) 
