### PR TITLE
refactor: use username not socketid

### DIFF
--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -36,9 +36,9 @@ export class PokerTable {
     return new ResultSuccess(newTable);
   }
 
-  public sitAtTable(seatNumber: string, clientId: string): Result<void> {
+  public sitAtTable(seatNumber: string, username: string): Result<void> {
     for (const seat of this.seats) {
-      if (seat.playerId === clientId) {
+      if (seat.username === username) {
         return Result.error(new PlayerAlreadySeatedError());
       }
     }
@@ -47,7 +47,7 @@ export class PokerTable {
         if (seat.isTaken) {
           return Result.error(new SeatTakenError());
         } else {
-          seat.playerId = clientId;
+          seat.username = username;
           seat.isTaken = true;
           return Result.success();
         }
@@ -56,10 +56,10 @@ export class PokerTable {
     return Result.error(new SeatNotFoundError());
   }
 
-  public leaveTable(seatNumber: string, clientId: string): Result<void> {
+  public leaveTable(seatNumber: string, username: string): Result<void> {
     for (const seat of this.seats) {
-      if (seat.playerId === clientId && seat.seatNumber === seatNumber) {
-        seat.playerId = '';
+      if (seat.username === username && seat.seatNumber === seatNumber) {
+        seat.username = '';
         seat.isTaken = false;
         return Result.success();
       }
@@ -84,7 +84,7 @@ export class PokerTable {
 
   public checkTableReady(): boolean {
     for (const seat of this.seats) {
-      if (seat.playerId == '') {
+      if (seat.username == '') {
         return false;
       }
     }

--- a/backend/src/game/Seat.ts
+++ b/backend/src/game/Seat.ts
@@ -3,16 +3,16 @@
  */
 export class Seat {
   public seatNumber: string;
-  public playerId: string;
+  public username: string;
   public isTaken: boolean;
 
-  public constructor(seatNumber: string, playerId: string, isTaken: boolean) {
+  public constructor(seatNumber: string, username: string, isTaken: boolean) {
     this.seatNumber = seatNumber;
-    this.playerId = playerId;
+    this.username = username;
     this.isTaken = isTaken;
   }
 
-  public static createSeat(seatNumber: string, playerId: string = '', isTaken: boolean = false): Seat {
-    return new Seat(seatNumber, playerId, isTaken);
+  public static createSeat(seatNumber: string, username: string = '', isTaken: boolean = false): Seat {
+    return new Seat(seatNumber, username, isTaken);
   }
 }

--- a/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
+++ b/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
@@ -20,9 +20,8 @@ class PokerTablesJoinHandler extends BaseHandler<PokerTableJoinPayload, PokerTab
     super(pokerTableJoinSchema, PokerTableJoinErrorCodes);
   }
 
-  protected getResult(payload: PokerTableJoinPayload, res: Response<PokerTableJoinOutput>) {
+  protected getResult(payload: PokerTableJoinPayload, res: Response<PokerTableJoinOutput>, username: string) {
     const seatNumber = payload.selectedSeatNumber;
-    const clientId = payload.socketId;
 
     const pokerTable = GameLobbyService.getTable('table_1');
 
@@ -30,7 +29,7 @@ class PokerTablesJoinHandler extends BaseHandler<PokerTableJoinPayload, PokerTab
       return this.handleError(new PokerTableDoesNotExistError(), res);
     }
 
-    const joinRoom = pokerTable.sitAtTable(seatNumber, clientId);
+    const joinRoom = pokerTable.sitAtTable(seatNumber, username);
 
     if (joinRoom.isError()) {
       debug(joinRoom.getError());
@@ -40,7 +39,7 @@ class PokerTablesJoinHandler extends BaseHandler<PokerTableJoinPayload, PokerTab
     // Emit event to all clients connected that a player has sat down
     const event = 'player_joined';
     const eventPayload = {
-      playerId: clientId,
+      username: username,
       seatId: seatNumber,
     };
 

--- a/backend/src/handlers/poker-tables/PokerTablesLeaveHandler.test.ts
+++ b/backend/src/handlers/poker-tables/PokerTablesLeaveHandler.test.ts
@@ -1,4 +1,5 @@
 import { apiTest } from '@tests/helpers/apiTest';
+import { mockMySqlSelectSessionSuccess } from '@tests/mocks/sessionMocks';
 import { shutDownServer } from '@tests/helpers/shutDownServer';
 import { ResultSuccess, ResultError } from '@infra/Result';
 
@@ -12,9 +13,10 @@ describe('poker-tables.leave', () => {
     jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
     jest.spyOn(Rooms, 'sendEventToRoom').mockImplementation(() => new ResultError(new RoomNotFoundError('table-1')));
     GameLobbyService.createPokerTable('table_1', 2);
+    mockMySqlSelectSessionSuccess('userone');
+
     const res = await apiTest('/api/actions/poker-tables.leave', {
       selectedSeatNumber: 1,
-      socketId: 'abc123',
     });
 
     expect(res.body.ok).toEqual(false);
@@ -26,16 +28,15 @@ describe('poker-tables.leave', () => {
   it('should remove a player from a table', async () => {
     jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-1'));
     GameLobbyService.createPokerTable('table_1', 2);
+    mockMySqlSelectSessionSuccess('userone');
 
     await apiTest('/api/actions/poker-tables.join', {
       selectedSeatNumber: 'seat-1',
-      socketId: 'abc123',
     });
-
     const res = await apiTest('/api/actions/poker-tables.leave', {
       selectedSeatNumber: 'seat-1',
-      socketId: 'abc123',
     });
+
     expect(res.statusCode).toEqual(200);
     expect(res.body.ok).toEqual(true);
   });
@@ -43,9 +44,10 @@ describe('poker-tables.leave', () => {
   it('should error when the player is not already sitting at the table', async () => {
     jest.spyOn(Rooms, 'createRoom').mockImplementation(() => new ResultSuccess('table-2'));
     GameLobbyService.createPokerTable('table_2', 2);
+    mockMySqlSelectSessionSuccess('userone');
+
     const res = await apiTest('/api/actions/poker-tables.leave', {
       selectedSeatNumber: 'seat-2',
-      socketId: 'def456',
     });
 
     expect(res.statusCode).toEqual(200);

--- a/backend/src/handlers/poker-tables/PokerTablesLeaveHandler.ts
+++ b/backend/src/handlers/poker-tables/PokerTablesLeaveHandler.ts
@@ -23,15 +23,15 @@ class PokerTablesLeaveHandler extends BaseHandler<PokerTableLeavePayload, PokerT
     super(pokerTableLeaveSchema, PokerTableLeaveErrorCodes);
   }
 
-  protected getResult(payload: PokerTableLeavePayload, res: Response<PokerTableLeaveOutput>) {
+  protected getResult(payload: PokerTableLeavePayload, res: Response<PokerTableLeaveOutput>, username: string) {
     const seatNumber = payload.selectedSeatNumber;
-    const clientId = payload.socketId;
+
     const pokerTable = GameLobbyService.getTable('table_1');
     if (!pokerTable) {
       return this.handleError(new PokerTableDoesNotExistError(), res);
     }
 
-    const leaveRoom = pokerTable.leaveTable(seatNumber, clientId);
+    const leaveRoom = pokerTable.leaveTable(seatNumber, username);
     if (leaveRoom.isError()) {
       debug(leaveRoom.getError());
       return this.handleError(leaveRoom.getError(), res);
@@ -40,7 +40,7 @@ class PokerTablesLeaveHandler extends BaseHandler<PokerTableLeavePayload, PokerT
     // Emit event to all clients connected that a player has sat down
     const event = 'player_left';
     const eventPayload = {
-      playerId: clientId,
+      username: username,
       seatId: seatNumber,
     };
     const sendEvents = Rooms.sendEventToRoom('table_1', event, eventPayload);

--- a/backend/src/handlers/signin/SigninHandler.test.ts
+++ b/backend/src/handlers/signin/SigninHandler.test.ts
@@ -1,6 +1,4 @@
-import request from 'supertest';
-
-import { httpServer } from '../../index';
+import { apiTestNoCookie } from '@tests/helpers/apiTest';
 import { shutDownServer } from '@tests/helpers/shutDownServer';
 
 import { mockMySqlSelectSuccess, mockMySqlSelectSuccessWithNoRows } from '../../tests/mocks/dbMocks';
@@ -8,9 +6,8 @@ import { mockMySqlSelectSuccess, mockMySqlSelectSuccessWithNoRows } from '../../
 describe('signin', () => {
   it('should authenticate the user successfully with correct credentials', async () => {
     mockMySqlSelectSuccess();
-    // mockMySqlSelectSessionSuccess();
 
-    const res = await request(httpServer).post('/api/actions/signin').send({
+    const res = await apiTestNoCookie('/api/actions/signin', {
       username: 'testuser',
       password: 'testpassword',
     });
@@ -20,7 +17,7 @@ describe('signin', () => {
   });
 
   it('should error when payload is invalid', async () => {
-    const res = await request(httpServer).post('/api/actions/signin').send({
+    const res = await apiTestNoCookie('/api/actions/signin', {
       username: '',
       password: '',
     });
@@ -32,7 +29,7 @@ describe('signin', () => {
   it('should respond with a password_invalid error when signing in with a password that is invalid', async () => {
     mockMySqlSelectSuccess();
 
-    const res = await request(httpServer).post('/api/actions/signin').send({
+    const res = await apiTestNoCookie('/api/actions/signin', {
       username: 'testuser',
       password: 'invalidpassword',
     });
@@ -44,7 +41,7 @@ describe('signin', () => {
   it('should respond with a username_not_found when signing in with a username that does not exist', async () => {
     mockMySqlSelectSuccessWithNoRows();
 
-    const res = await request(httpServer).post('/api/actions/signin').send({
+    const res = await apiTestNoCookie('/api/actions/signin', {
       username: 'invaliduser',
       password: 'invalidpasword',
     });

--- a/backend/src/handlers/signin/SigninHandler.ts
+++ b/backend/src/handlers/signin/SigninHandler.ts
@@ -18,10 +18,11 @@ class SigninHandler extends BaseHandler<SigninPayload, SigninOutput> {
     super(signinSchema, SigninErrorCodes, false);
   }
 
+  //
   public async getResult(
     payload: SigninPayload,
     res: Response<SigninOutput>,
-    user: string,
+    _user: string /* unused, used in other class methods */,
     req: Request<SigninPayload>
   ) {
     // TODO: need to validate username. task: 86cv07w0c

--- a/backend/src/handlers/users/UsersCreateHandler.test.ts
+++ b/backend/src/handlers/users/UsersCreateHandler.test.ts
@@ -1,21 +1,23 @@
-import { apiTest } from '@tests/helpers/apiTest';
+import { apiTestNoCookie } from '@tests/helpers/apiTest';
 import { shutDownServer } from '@tests/helpers/shutDownServer';
 
 describe('users.create', () => {
   it('should error when payload is invalid', async () => {
-    const res = await apiTest('/api/actions/users.create', {
+    const res = await apiTestNoCookie('/api/actions/users.create', {
       username: '',
       password: 'abc123',
     });
+
     expect(res.body.ok).toEqual(false);
     expect(res.body.error.errorCode).toEqual('invalid_request_payload');
   });
 
   it('should create a user', async () => {
-    const res = await apiTest('/api/actions/users.create', {
+    const res = await apiTestNoCookie('/api/actions/users.create', {
       username: 'test',
       password: 'abc123',
     });
+
     expect(res.statusCode).toEqual(200);
     expect(res.body.ok).toEqual(false);
     expect(res.body.error.errorCode).toEqual('method_not_implemented');

--- a/backend/src/handlers/users/UsersCreateHandler.ts
+++ b/backend/src/handlers/users/UsersCreateHandler.ts
@@ -16,7 +16,7 @@ import { BaseHandler } from '../BaseHandler';
 class UsersCreateHandler extends BaseHandler<UsersCreatePayload, UsersCreateOutput> {
   // We pass the Joi schema to the parent class (BaseHandler) which is used to validate incoming payloads in the runHandler (in the parent class)
   constructor() {
-    super(usersCreateSchema, UsersCreateErrorCodes);
+    super(usersCreateSchema, UsersCreateErrorCodes, false);
   }
 
   protected getResult(payload: UsersCreatePayload, res: Response<UsersCreateOutput>) {

--- a/backend/src/shared/api/poker-tables/types/PokerTableJoin.ts
+++ b/backend/src/shared/api/poker-tables/types/PokerTableJoin.ts
@@ -6,7 +6,6 @@ import Joi from 'joi';
 
 export type PokerTableJoinPayload = {
   selectedSeatNumber: string;
-  socketId: string;
 };
 
 export interface PokerTableJoinOutput extends BaseOutput {}
@@ -14,7 +13,6 @@ export interface PokerTableJoinOutput extends BaseOutput {}
 // Joi schema
 export const pokerTableJoinSchema = Joi.object<PokerTableJoinPayload>({
   selectedSeatNumber: Joi.string().required(),
-  socketId: Joi.string().required(),
 });
 
 export enum PokerTableJoinErrorCodes {

--- a/backend/src/shared/api/poker-tables/types/PokerTableLeave.ts
+++ b/backend/src/shared/api/poker-tables/types/PokerTableLeave.ts
@@ -6,7 +6,6 @@ import Joi from 'joi';
 
 export type PokerTableLeavePayload = {
   selectedSeatNumber: string;
-  socketId: string;
 };
 
 export interface PokerTableLeaveOutput extends BaseOutput {}
@@ -14,7 +13,6 @@ export interface PokerTableLeaveOutput extends BaseOutput {}
 // Joi schema
 export const pokerTableLeaveSchema = Joi.object<PokerTableLeavePayload>({
   selectedSeatNumber: Joi.string().required(),
-  socketId: Joi.string().required(),
 });
 
 export enum PokerTableLeaveErrorCodes {

--- a/backend/src/tests/helpers/apiTest.ts
+++ b/backend/src/tests/helpers/apiTest.ts
@@ -1,13 +1,14 @@
 // Internal
 import request from 'supertest';
 import { httpServer } from '../../index';
-import { mockMySqlSelectSessionSuccess } from '@tests/mocks/sessionMocks';
 
 export async function apiTest(endpoint: string, payload: any) {
-  mockMySqlSelectSessionSuccess();
-
   return await request(httpServer)
     .post(endpoint)
     .set('Cookie', ['connect.sid=s%3AbcI-pLBR9KclcJ1iPAqSW_93mKMhM0pa.zzBmloQUPbqNiCGkSZ4KwoBOkcnWFUOhquX8Y%2BGAz40'])
     .send(payload);
+}
+
+export async function apiTestNoCookie(endpoint: string, payload: any) {
+  return await request(httpServer).post(endpoint).send(payload);
 }

--- a/backend/src/tests/mocks/sessionMocks.ts
+++ b/backend/src/tests/mocks/sessionMocks.ts
@@ -3,14 +3,13 @@ import { RowDataPacket } from 'mysql2/promise';
 import { ResultSuccess } from '@infra/Result';
 import { MySqLInstance } from '../../db/my-sql';
 
-export const mockMySqlSelectSessionSuccess = () => {
+export const mockMySqlSelectSessionSuccess = (username: string) => {
   jest.spyOn(MySqLInstance, 'select').mockImplementation(
     async () =>
       await new ResultSuccess([
         {
           session_id: 'bcI-pLBR9KclcJ1iPAqSW_93mKMhM0pd',
-          session_data:
-            '{"cookie":{"originalMaxAge":null,"expires":null,"httpOnly":true,"path":"/"},"username":"richard","authenticated":true}',
+          session_data: `{"cookie":{"originalMaxAge":null,"expires":null,"httpOnly":true,"path":"/"},"username":"${username}","authenticated":true}`,
         },
       ] as RowDataPacket[])
   );

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -1,33 +1,31 @@
-import React, { useCallback } from 'react';
-import { Socket } from 'socket.io-client'; // RAVIEW: remove
+import { useCallback } from 'react';
 
 import apiCall from '../../../fetch/apiCall';
 
 type SeatProps = {
   seatNumber: string;
   chipCount: number;
-  socket: Socket;
 };
 
-export default function Seat({ seatNumber, chipCount, socket }: SeatProps) {
+export default function Seat({ seatNumber, chipCount }: SeatProps) {
   const onPlayerSit = useCallback(async () => {
-    const payload = { selectedSeatNumber: seatNumber, socketId: socket.id };
+    const payload = { selectedSeatNumber: seatNumber };
 
     const result = await apiCall.post('poker-tables.join', payload);
     if (!result?.ok) {
       // Do something with the error
       console.log(result?.error);
     }
-  }, [seatNumber, socket]);
+  }, [seatNumber]);
 
   const playerLeave = useCallback(async () => {
-    const payload = { selectedSeatNumber: seatNumber, socketId: socket.id };
+    const payload = { selectedSeatNumber: seatNumber };
     const result = await apiCall.post('poker-tables.leave', payload);
     if (!result?.ok) {
       // Do something with the error
       console.log(result?.error);
     }
-  }, [seatNumber, socket]);
+  }, [seatNumber]);
 
   return (
     <div>

--- a/frontend/src/components/Table/Seat/Seat.tsx
+++ b/frontend/src/components/Table/Seat/Seat.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Socket } from 'socket.io-client';
+import { Socket } from 'socket.io-client'; // RAVIEW: remove
 
 import apiCall from '../../../fetch/apiCall';
 

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import './Table.css';
-import { socket } from '../../Socket';
+import { socket } from '../../Socket'; // RAVIEW: remove
 
 import Pot from './Pot/Pot';
 import Board from './Board/Board';

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -1,5 +1,4 @@
 import './Table.css';
-import { socket } from '../../Socket'; // RAVIEW: remove
 
 import Pot from './Pot/Pot';
 import Board from './Board/Board';
@@ -13,8 +12,8 @@ export function Table({}: TableProps) {
       <div id="table">
         <Pot />
         <Board />
-        <Seat seatNumber="seat-1" chipCount={1000} socket={socket} />
-        <Seat seatNumber="seat-2" chipCount={1000} socket={socket} />
+        <Seat seatNumber="seat-1" chipCount={1000} />
+        <Seat seatNumber="seat-2" chipCount={1000} />
       </div>
       <Actions />
     </>


### PR DESCRIPTION
### Description

This is the tidy up task for changing our endpoints to use the username instead of the socket id that we originally anchored on. 

It should now make it easy to see who is who when debugging and add a username to the seat when seated etc.

### How to test

<!--- Steps on how to test this change  --->

1. Sign in to two accounts 
2. Sit and leave

- Unit and API tests should succeed

- Bonus: Check out the websocket to now see the username:
<img width="1503" alt="Screenshot 2024-04-09 at 8 52 07 am" src="https://github.com/richardaspinall/poker-react-node/assets/15721687/a4cec817-8c37-4c85-9505-6b89286d28a7">

### Task

[CU-86cv2qrea ](https://app.clickup.com/t/86cv2qrea)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests