### PR TITLE
feat: add redux with player joined and player left

### DIFF
--- a/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
+++ b/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
@@ -37,6 +37,7 @@ class PokerTablesJoinHandler extends BaseHandler<PokerTableJoinPayload, PokerTab
       return this.handleError(joinRoom.getError(), res);
     }
 
+    // Emit event to all clients connected that a player has sat down
     const event = 'player_joined';
     const playerJoinedEventPayload = {
       username: username,

--- a/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
+++ b/backend/src/handlers/poker-tables/PokerTablesJoinHandler.ts
@@ -37,7 +37,6 @@ class PokerTablesJoinHandler extends BaseHandler<PokerTableJoinPayload, PokerTab
       return this.handleError(joinRoom.getError(), res);
     }
 
-    // Emit event to all clients connected that a player has sat down
     const event = 'player_joined';
     const playerJoinedEventPayload = {
       username: username,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.2.3",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/socket.io-client": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^9.1.0",
         "react-router-dom": "^6.22.2",
+        "redux": "^5.0.1",
         "socket.io-client": "^4.7.2"
       },
       "devDependencies": {
@@ -919,6 +922,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
@@ -1077,13 +1103,13 @@
       "version": "15.7.8",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.8.tgz",
       "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz",
       "integrity": "sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1103,7 +1129,7 @@
       "version": "0.16.4",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
       "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -1119,6 +1145,11 @@
       "dependencies": {
         "socket.io-client": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.7.5",
@@ -1603,7 +1634,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2217,6 +2248,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+      "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
@@ -2753,6 +2793,32 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -2803,6 +2869,24 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3155,6 +3239,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/vite": {
@@ -3827,6 +3919,17 @@
         "fastq": "^1.6.0"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "requires": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      }
+    },
     "@remix-run/router": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
@@ -3962,13 +4065,13 @@
       "version": "15.7.8",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.8.tgz",
       "integrity": "sha512-kMpQpfZKSCBqltAJwskgePRaYRFukDkm1oItcAbC3gNELR20XIBcN9VRgg4+m8DKsTfkWeA4m4Imp4DDuWy7FQ==",
-      "dev": true
+      "devOptional": true
     },
     "@types/react": {
       "version": "18.2.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz",
       "integrity": "sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3988,7 +4091,7 @@
       "version": "0.16.4",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
       "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ==",
-      "dev": true
+      "devOptional": true
     },
     "@types/semver": {
       "version": "7.5.3",
@@ -4003,6 +4106,11 @@
       "requires": {
         "socket.io-client": "*"
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.7.5",
@@ -4310,7 +4418,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "debug": {
       "version": "4.3.4",
@@ -4764,6 +4872,11 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immer": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+      "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw=="
+    },
     "immutable": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
@@ -5140,6 +5253,15 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "requires": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -5171,6 +5293,22 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "requires": {}
+    },
+    "reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -5397,6 +5535,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "vite": {
       "version": "4.5.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.2.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "@types/socket.io-client": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^9.1.0",
     "react-router-dom": "^6.22.2",
+    "redux": "^5.0.1",
     "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/socket.io-client": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",

--- a/frontend/src/components/PokerTable/PokerTable.tsx
+++ b/frontend/src/components/PokerTable/PokerTable.tsx
@@ -1,11 +1,11 @@
 import { useSelector } from 'react-redux';
 
 import { selectSeats } from '../../store/selectors.ts';
-import Actions from './Actions/Actions.tsx';
-import Board from './Board/Board.tsx';
+import Actions from './Actions/Actions';
+import Board from './Board/Board';
 import './PokerTable.css';
-import Pot from './Pot/Pot.tsx';
-import Seat from './Seat/Seat.tsx';
+import Pot from './Pot/Pot';
+import Seat from './Seat/Seat';
 import { useSubscribeToGameEvents } from './hooks/useSubscribeToGameEvents.ts';
 
 type PokerTableProps = {};
@@ -15,7 +15,7 @@ export function PokerTable({}: PokerTableProps) {
   const seats = useSelector(selectSeats);
   return (
     <>
-      <div id="pokertable">
+      <div id="poker-table">
         <Pot />
         <Board />
         {seats.value?.map((seat) => (

--- a/frontend/src/components/PokerTable/PokerTable.tsx
+++ b/frontend/src/components/PokerTable/PokerTable.tsx
@@ -1,21 +1,26 @@
-import Actions from './Actions/Actions';
-import Board from './Board/Board';
+import { useSelector } from 'react-redux';
+
+import { selectSeats } from '../../store/selectors.ts';
+import Actions from './Actions/Actions.tsx';
+import Board from './Board/Board.tsx';
 import './PokerTable.css';
-import Pot from './Pot/Pot';
-import Seat from './Seat/Seat';
-import { useSubscribeToGameEvents } from './hooks/useSubscribeToGameEvents';
+import Pot from './Pot/Pot.tsx';
+import Seat from './Seat/Seat.tsx';
+import { useSubscribeToGameEvents } from './hooks/useSubscribeToGameEvents.ts';
 
 type PokerTableProps = {};
 export function PokerTable({}: PokerTableProps) {
   useSubscribeToGameEvents(); // Subscribe to socket events like player joined and player left
 
+  const seats = useSelector(selectSeats);
   return (
     <>
-      <div id="poker-table">
+      <div id="pokertable">
         <Pot />
         <Board />
-        <Seat seatNumber="seat-1" chipCount={1000} />
-        <Seat seatNumber="seat-2" chipCount={1000} />
+        {seats.value?.map((seat) => (
+          <Seat key={seat.seatNumber} seatNumber={seat.seatNumber} userName={seat.player?.username} chipCount={1000} />
+        ))}
       </div>
       <Actions />
     </>

--- a/frontend/src/components/PokerTable/Seat/Seat.tsx
+++ b/frontend/src/components/PokerTable/Seat/Seat.tsx
@@ -4,10 +4,11 @@ import apiCall from '../../../fetch/apiCall';
 
 type SeatProps = {
   seatNumber: string;
+  userName?: string;
   chipCount: number;
 };
 
-export default function Seat({ seatNumber, chipCount }: SeatProps) {
+export default function Seat({ seatNumber, userName, chipCount }: SeatProps) {
   const onPlayerSit = useCallback(async () => {
     const payload = { selectedSeatNumber: seatNumber };
 
@@ -30,7 +31,7 @@ export default function Seat({ seatNumber, chipCount }: SeatProps) {
   return (
     <div>
       <button className="seat" id={seatNumber} data-chip-count={chipCount} onClick={onPlayerSit}>
-        Empty
+        {userName ? userName : 'Empty'}
       </button>
       <button onClick={playerLeave}>Leave Seat {seatNumber}</button>
     </div>

--- a/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
+++ b/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useSocket } from '../../../hooks/useSocket';
+import { addUser, removeUser } from '../../../store/seatsSlice';
 
 /*
  * This hook uses the subscribeToEvent function from useSocket to add events to
@@ -9,15 +11,18 @@ import { useSocket } from '../../../hooks/useSocket';
  * TODO: We may want to split this into multiple hooks if the number of events grows.
  */
 export function useSubscribeToGameEvents() {
+  const dispatch = useDispatch();
   const { subscribeToEvent } = useSocket();
 
   useEffect(() => {
-    const subscribeToPlayerJoined = subscribeToEvent('player_joined', () => {
+    const subscribeToPlayerJoined = subscribeToEvent('player_joined', (playerData) => {
       console.log('Player sat down');
+      dispatch(addUser({ username: playerData.username, seatNumber: playerData.seatNumber }));
     });
-
-    const subscribeToPlayerLeave = subscribeToEvent('player_left', () => {
+    const subscribeToPlayerLeave = subscribeToEvent('player_left', (playerData) => {
       console.log('Player left the table');
+
+      dispatch(removeUser({ username: playerData.username, seatNumber: playerData.seatNumber }));
     });
 
     const subscribeToStartGame = subscribeToEvent('start_game', () => {
@@ -29,5 +34,5 @@ export function useSubscribeToGameEvents() {
       subscribeToPlayerLeave();
       subscribeToStartGame();
     };
-  }, [subscribeToEvent]);
+  }, [dispatch, subscribeToEvent]);
 }

--- a/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
+++ b/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
@@ -15,14 +15,15 @@ export function useSubscribeToGameEvents() {
   const { subscribeToEvent } = useSocket();
 
   useEffect(() => {
-    const subscribeToPlayerJoined = subscribeToEvent('player_joined', (playerData) => {
+    const subscribeToPlayerJoined = subscribeToEvent('player_joined', (payload) => {
       console.log('Player sat down');
-      dispatch(addUser({ username: playerData.username, seatNumber: playerData.seatNumber }));
+
+      dispatch(addUser({ username: payload.username, seatNumber: payload.seatNumber }));
     });
-    const subscribeToPlayerLeave = subscribeToEvent('player_left', (playerData) => {
+    const subscribeToPlayerLeft = subscribeToEvent('player_left', (payload) => {
       console.log('Player left the table');
 
-      dispatch(removeUser({ username: playerData.username, seatNumber: playerData.seatNumber }));
+      dispatch(removeUser({ username: payload.username, seatNumber: payload.seatNumber }));
     });
 
     const subscribeToStartGame = subscribeToEvent('start_game', () => {
@@ -31,7 +32,7 @@ export function useSubscribeToGameEvents() {
 
     return () => {
       subscribeToPlayerJoined();
-      subscribeToPlayerLeave();
+      subscribeToPlayerLeft();
       subscribeToStartGame();
     };
   }, [dispatch, subscribeToEvent]);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 
 import App from './App.tsx';
+import store from './store/store.tsx';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>
 );

--- a/frontend/src/store/seatsSlice.tsx
+++ b/frontend/src/store/seatsSlice.tsx
@@ -1,0 +1,69 @@
+import { PayloadAction, SerializedError, createSlice } from '@reduxjs/toolkit';
+
+import {
+  PlayerJoinedEvent,
+  PlayerLeftEvent,
+} from '../../../backend/src/shared/websockets/poker-tables/types/PokerTableEvents';
+
+type Seat = {
+  seatNumber: string;
+  player?: {
+    username: string;
+  };
+};
+
+interface SeatsSlice {
+  value: Seat[];
+  loading: boolean;
+  error: SerializedError | null;
+}
+
+// this is our state for the seats
+// a slice of the state pie
+const initialState: SeatsSlice = {
+  value: [
+    {
+      seatNumber: 'seat-1',
+    },
+    {
+      seatNumber: 'seat-2',
+    },
+  ],
+  loading: false,
+  error: null,
+};
+
+function updateSeats(seats: Seat[], seatNumber: string, player: { username: string } | undefined = undefined) {
+  const seatIndex = seats.findIndex((seat) => seat.seatNumber === seatNumber);
+
+  if (seatIndex !== -1) {
+    seats[seatIndex].player = player;
+  }
+
+  return seats;
+}
+// https://redux-toolkit.js.org/api/createslice
+// safe to muttate state in createSlice as it uses immer under the hood
+//
+// the reducers are the actions that can be dispatched to change the state
+export const seatsSlice = createSlice({
+  name: 'seats',
+  initialState,
+  reducers: {
+    setSeats: (state, action: PayloadAction<SeatsSlice>) => {
+      state = action.payload;
+    },
+    addUser: (state, action: PayloadAction<PlayerJoinedEvent>) => {
+      const { username, seatNumber } = action.payload;
+      state.value = updateSeats(state.value, seatNumber, { username });
+    },
+    removeUser: (state, action: PayloadAction<PlayerLeftEvent>) => {
+      const { seatNumber } = action.payload;
+      state.value = updateSeats(state.value, seatNumber);
+    },
+  },
+});
+
+export const { setSeats, addUser, removeUser } = seatsSlice.actions;
+
+export default seatsSlice.reducer;

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -1,0 +1,10 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import { RootState } from './store';
+
+export const selectSeats = createSelector(
+  (state: RootState) => state.seats, // This is the input selector
+  (seats) => {
+    return { ...seats };
+  }
+);

--- a/frontend/src/store/store.tsx
+++ b/frontend/src/store/store.tsx
@@ -1,0 +1,20 @@
+import { useDispatch } from 'react-redux';
+
+import { configureStore } from '@reduxjs/toolkit';
+
+import seatsReducer from './seatsSlice';
+
+const store = configureStore({
+  reducer: {
+    seats: seatsReducer,
+  },
+});
+
+// Type for the store's state
+export type RootState = ReturnType<typeof store.getState>;
+
+// Type for the store's dispatch function
+export type AppDispatch = typeof store.dispatch;
+export const useAppDispatch: () => AppDispatch = useDispatch;
+
+export default store;


### PR DESCRIPTION
# !!! Install all `npm run install:all` to install redux toolkit

### Description

<!--- What Why How... you made this change --->

This PR adds Redux and makes use of it with playerJoinedEvents and playerLeftEvents

### How to test

<!--- Steps on how to test this change  --->


Then:
1. Head to the game and sign in
2. Click on a seat
3. Note your name appears

![huzza](https://github.com/richardaspinall/poker-react-node/assets/15721687/e19fb513-a46c-44ed-aea4-d38e52d2932e)

### Task

[CU-86cudgwx9](https://app.clickup.com/t/86cudgwx9) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
