### PR TITLE
refactor: handlers are strict on output validation for excess fields and now return result

### DIFF
--- a/backend/src/handlers/users/UsersCreateHandler.ts
+++ b/backend/src/handlers/users/UsersCreateHandler.ts
@@ -1,9 +1,13 @@
-import type { Response } from 'express';
-
+import { ResultError } from '@infra/Result';
 import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { UsersCreateErrorCodes } from '@shared/api/users/types/UsersCreate';
 
-import { UsersCreateOutput, UsersCreatePayload, usersCreateSchema } from '../../shared/api/users/types/UsersCreate';
+import {
+  UsersCreateOutput,
+  UsersCreateOutputSchema,
+  UsersCreatePayload,
+  UsersCreatePayloadSchema,
+} from '../../shared/api/users/types/UsersCreate';
 import { BaseHandler } from '../BaseHandler';
 
 /**
@@ -12,14 +16,14 @@ import { BaseHandler } from '../BaseHandler';
 class UsersCreateHandler extends BaseHandler<UsersCreatePayload, UsersCreateOutput> {
   // We pass the Joi schema to the parent class (BaseHandler) which is used to validate incoming payloads in the runHandler (in the parent class)
   constructor() {
-    super(usersCreateSchema, UsersCreateErrorCodes, false);
+    super(UsersCreatePayloadSchema, UsersCreateOutputSchema, UsersCreateErrorCodes, false);
   }
 
-  protected getResult(payload: UsersCreatePayload, res: Response<UsersCreateOutput>) {
+  protected async getResult(payload: UsersCreatePayload) {
     const username = payload.username;
     const password = payload.password;
 
-    return this.handleError(new MethodNotImplementedError(), res);
+    return new ResultError(new MethodNotImplementedError());
   }
 }
 

--- a/backend/src/shared/api/poker-tables/types/PokerTableJoin.ts
+++ b/backend/src/shared/api/poker-tables/types/PokerTableJoin.ts
@@ -8,10 +8,13 @@ export type PokerTableJoinPayload = {
 
 export interface PokerTableJoinOutput extends BaseOutput {}
 
-// Joi schema
-export const pokerTableJoinSchema = Joi.object<PokerTableJoinPayload>({
+export const PokerTableJoinPayloadSchema = Joi.object<PokerTableJoinPayload>({
   selectedSeatNumber: Joi.string().required(),
 });
+
+export const PokerTableJoinOutputSchema = Joi.object({
+  ok: Joi.boolean().required(),
+}).unknown(false);
 
 export enum PokerTableJoinErrorCodes {
   SeatTaken = 'seat_taken',

--- a/backend/src/shared/api/poker-tables/types/PokerTableLeave.ts
+++ b/backend/src/shared/api/poker-tables/types/PokerTableLeave.ts
@@ -8,10 +8,13 @@ export type PokerTableLeavePayload = {
 
 export interface PokerTableLeaveOutput extends BaseOutput {}
 
-// Joi schema
-export const pokerTableLeaveSchema = Joi.object<PokerTableLeavePayload>({
+export const pokerTableLeavePayloadSchema = Joi.object<PokerTableLeavePayload>({
   selectedSeatNumber: Joi.string().required(),
 });
+
+export const pokerTableLeaveOutputSchema = Joi.object({
+  ok: Joi.boolean().required(),
+}).unknown(false);
 
 export enum PokerTableLeaveErrorCodes {
   SeatTaken = 'seat_taken',

--- a/backend/src/shared/api/users/types/UsersCreate.ts
+++ b/backend/src/shared/api/users/types/UsersCreate.ts
@@ -9,11 +9,14 @@ export type UsersCreatePayload = {
 
 export interface UsersCreateOutput extends BaseOutput {}
 
-// Joi schema
-export const usersCreateSchema = Joi.object<UsersCreatePayload>({
+export const UsersCreatePayloadSchema = Joi.object<UsersCreatePayload>({
   username: Joi.string().required(),
   password: Joi.string().required(),
 });
+
+export const UsersCreateOutputSchema = Joi.object({
+  ok: Joi.boolean().required(),
+}).unknown(false);
 
 export enum UsersCreateErrorCodes {
   UsernameTaken = 'username_taken',

--- a/backend/src/shared/signin/types/Signin.ts
+++ b/backend/src/shared/signin/types/Signin.ts
@@ -9,11 +9,14 @@ export type SigninPayload = {
 
 export interface SigninOutput extends BaseOutput {}
 
-// Joi schema
-export const signinSchema = Joi.object<SigninPayload>({
+export const SigninPayloadSchema = Joi.object<SigninPayload>({
   username: Joi.string().required(),
   password: Joi.string().required(),
 });
+
+export const SigninOutputSchema = Joi.object({
+  ok: Joi.boolean().required(),
+}).unknown(false);
 
 export enum SigninErrorCodes {
   UsernameNotFound = 'username_not_found',


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

I found when implementing the getSeats endpoint that we could return additional fields to the client accidentally (the seats isTaken field). This is a complicated problem with how Typescript deals with types, in some cases it will return all fields as long as the ones that it has typed for are there (Excess Property Checks don't happend unless it is an object literal).

This PR adds strict typing for the output via JOI to validate the output of each handler payload, so now an output schema needs to be added to the handler when implemented and then only these fields will be able to return from the endpoint (otherwise there will be an error). The base handler's `runHandler` will take care of the rest.

Additionally each handler now needs to return a Result instead of calling `this.errorHandler` or directly sending `res.send`. This means that our handlers are even cleaner from infrastructure (no req or res with the exception of the signin and create handlers)


### How to test

<!--- Steps on how to test this change  --->
- Everything should run as per normal
- All tests should pass

### Task

[CU-86cv6gqnh](https://app.clickup.com/t/86cv6gqnh) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
