### PR TITLE
refactor: make validatePayload more flexible

### DIFF
--- a/backend/src/handlers/BaseHandler.ts
+++ b/backend/src/handlers/BaseHandler.ts
@@ -8,6 +8,7 @@ import type { BaseOutput } from '@shared/api/BaseOutput';
 
 import { Logger } from '../utils/Logger';
 import { ErrorHandler } from './ErrorHandler';
+import { InvalidRequestPayloadError, InvalidResponsePayloadError } from './ValidationErrors';
 import { UserNotAuthedError } from './users/errors/UserNotAuthedError';
 import { validatePayload } from './validatePayload';
 
@@ -59,7 +60,7 @@ export abstract class BaseHandler<TPayload, TOutput extends BaseOutput> implemen
 
     if (payload.isError()) {
       const error = payload.getError();
-      return this.handleError(error, res);
+      return this.handleError(new InvalidRequestPayloadError(error), res);
     }
 
     const userParam = this.requiresAuthentication ? user : undefined;
@@ -73,7 +74,8 @@ export abstract class BaseHandler<TPayload, TOutput extends BaseOutput> implemen
     const outputPayload = validatePayload<TOutput>(this.outputValidationSchema, output.getValue());
     if (outputPayload.isError()) {
       const error = outputPayload.getError();
-      return this.handleError(error, res);
+
+      return this.handleError(new InvalidResponsePayloadError(error), res);
     }
 
     return res.send(outputPayload.getValue());

--- a/backend/src/handlers/ValidationErrors.ts
+++ b/backend/src/handlers/ValidationErrors.ts
@@ -1,7 +1,19 @@
 import { BaseError } from '@infra/BaseError';
 
+export class InvalidPayloadError extends BaseError {
+  constructor(details: any) {
+    super('invalid_payload', 'Invalid payload', details);
+  }
+}
+
 export class InvalidRequestPayloadError extends BaseError {
   constructor(details: any) {
     super('invalid_request_payload', 'Invalid request payload', details);
+  }
+}
+
+export class InvalidResponsePayloadError extends BaseError {
+  constructor(details: any) {
+    super('invalid_response_payload', 'Invalid response payload', details);
   }
 }

--- a/backend/src/handlers/validatePayload.test.ts
+++ b/backend/src/handlers/validatePayload.test.ts
@@ -35,7 +35,7 @@ describe('validatePayload', () => {
       someNumber: 'one two three',
     };
     const result = validatePayload(joiSchema, payload);
-    expect(result.getError().code).toBe('invalid_request_payload');
+    expect(result.getError().code).toBe('invalid_payload');
   });
 
   it('should return an error when a required field is missing', () => {
@@ -43,6 +43,6 @@ describe('validatePayload', () => {
       someString: 'Hello World',
     };
     const result = validatePayload(joiSchema, payload);
-    expect(result.getError().code).toBe('invalid_request_payload');
+    expect(result.getError().code).toBe('invalid_payload');
   });
 });

--- a/backend/src/handlers/validatePayload.ts
+++ b/backend/src/handlers/validatePayload.ts
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import { Result, ResultError, ResultSuccess } from '@infra/Result';
 
 import { Logger } from '../utils/Logger';
-import { InvalidRequestPayloadError } from './ValidationErrors';
+import { InvalidPayloadError } from './ValidationErrors';
 
 const debug = Logger.newDebugger('APP:Validation');
 
@@ -23,7 +23,7 @@ export function validatePayload<TPayload>(
 
   if (error) {
     debug(error.details);
-    return new ResultError(new InvalidRequestPayloadError(error.details));
+    return new ResultError(new InvalidPayloadError(error.details));
   }
 
   return new ResultSuccess(value);


### PR DESCRIPTION
### Description

With this PR we remove the coupling of validatePayload and the `invalid_request_payload` error and make it generic to `invalid_payload` then make the BaseHandler decide which one it is actually going to return. 

This means that we will automatically return internal errors when the output payload is wrong.

### How to test

Tests should pass

### Task

[CU-86cv6hqh0](https://app.clickup.com/t/86cv6hqh0) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests
- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
