### PR TITLE
feat: display seats information on load

### DIFF
--- a/frontend/src/components/PokerTable/PokerTable.tsx
+++ b/frontend/src/components/PokerTable/PokerTable.tsx
@@ -1,25 +1,35 @@
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { selectSeats } from '../../store/selectors.ts';
+import { AppDispatch } from '../../store/store.tsx';
 import Actions from './Actions/Actions';
 import Board from './Board/Board';
 import './PokerTable.css';
 import Pot from './Pot/Pot';
 import Seat from './Seat/Seat';
+import fetchSeats from './fetchSeats.ts';
 import { useSubscribeToGameEvents } from './hooks/useSubscribeToGameEvents.ts';
 
 type PokerTableProps = {};
 export function PokerTable({}: PokerTableProps) {
+  const dispatch: AppDispatch = useDispatch();
+
   useSubscribeToGameEvents(); // Subscribe to socket events like player joined and player left
 
+  useEffect(() => {
+    dispatch(fetchSeats({ pokerTableName: 'table_1' })); // getTable state from server
+  }, []);
+
   const seats = useSelector(selectSeats);
+  console.log('TEST', seats);
   return (
     <>
       <div id="poker-table">
         <Pot />
         <Board />
         {seats.value?.map((seat) => (
-          <Seat key={seat.seatNumber} seatNumber={seat.seatNumber} userName={seat.player?.username} chipCount={1000} />
+          <Seat key={seat.seatNumber} seatNumber={seat.seatNumber} userName={seat.username} chipCount={1000} />
         ))}
       </div>
       <Actions />

--- a/frontend/src/components/PokerTable/fetchSeats.ts
+++ b/frontend/src/components/PokerTable/fetchSeats.ts
@@ -1,0 +1,25 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import { PokerTableGetSeatsPayload } from '../../../../backend/src/shared/api/poker-tables/types/PokerTableGetSeats';
+import apiCall from '../../fetch/apiCall';
+
+const fetchSeats = createAsyncThunk(
+  'pokerTables/getState',
+  // if you type your function argument here
+  async (payload: PokerTableGetSeatsPayload, thunkApi) => {
+    try {
+      const result = await apiCall.post('poker-tables.getSeats', payload);
+      if (result?.ok) {
+        console.log(result);
+      } else {
+        console.log('error', result?.error);
+      }
+
+      return result.seats;
+    } catch (error) {
+      return thunkApi.rejectWithValue(error);
+    }
+  }
+);
+
+export default fetchSeats;

--- a/frontend/src/store/seatsSlice.tsx
+++ b/frontend/src/store/seatsSlice.tsx
@@ -4,12 +4,11 @@ import {
   PlayerJoinedEvent,
   PlayerLeftEvent,
 } from '../../../backend/src/shared/websockets/poker-tables/types/PokerTableEvents';
+import fetchSeats from '../components/PokerTable/fetchSeats';
 
 type Seat = {
   seatNumber: string;
-  player?: {
-    username: string;
-  };
+  username?: string;
 };
 
 interface SeatsSlice {
@@ -33,11 +32,11 @@ const initialState: SeatsSlice = {
   error: null,
 };
 
-function updateSeats(seats: Seat[], seatNumber: string, player: { username: string } | undefined = undefined) {
+function updateSeats(seats: Seat[], seatNumber: string, username: string | undefined = undefined) {
   const seatIndex = seats.findIndex((seat) => seat.seatNumber === seatNumber);
 
   if (seatIndex !== -1) {
-    seats[seatIndex].player = player;
+    seats[seatIndex].username = username;
   }
 
   return seats;
@@ -55,12 +54,27 @@ export const seatsSlice = createSlice({
     },
     addUser: (state, action: PayloadAction<PlayerJoinedEvent>) => {
       const { username, seatNumber } = action.payload;
-      state.value = updateSeats(state.value, seatNumber, { username });
+      state.value = updateSeats(state.value, seatNumber, username);
     },
     removeUser: (state, action: PayloadAction<PlayerLeftEvent>) => {
       const { seatNumber } = action.payload;
       state.value = updateSeats(state.value, seatNumber);
     },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSeats.pending, (seatsSlice) => {
+        seatsSlice.loading = true;
+      })
+      .addCase(fetchSeats.fulfilled, (seatsSlice, action) => {
+        seatsSlice.loading = false;
+        seatsSlice.value = action.payload;
+      })
+      .addCase(fetchSeats.rejected, (seatsSlice, action) => {
+        seatsSlice.loading = false;
+        // Assigning the error message to the state
+        seatsSlice.error = action.error;
+      });
   },
 });
 


### PR DESCRIPTION
### Description

This PR adds a thunk for getting the seats on load through a useEffect. 

### How to test

<!--- Steps on how to test this change  --->
- Nothing should change joining and leaving a seat. Once we have started saving a poker table and the state of it to the DB, then we will see what this actually does

### Task

[CU-86cv49pwt](https://app.clickup.com/t/86cv49pwt)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
