### PR TITLE
fix: import order on save

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "singleQuote": true,
   "printWidth": 120,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
   "importOrder": ["^components/(.*)$", "^@(.*)/(.*)$", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true


### PR DESCRIPTION
### Description

Real simple change. This should fix the backend being flaky when saving for import order. 

Alternatively we can use:

https://github.com/IanVS/prettier-plugin-sort-imports

### Task:

[CU-86cv7mnmk](https://app.clickup.com/t/86cv7mnmk) 