### PR TITLE
refactor: move gen errors to shared folder

### DIFF
--- a/backend/src/scripts/generate-handler/generateHandler.js
+++ b/backend/src/scripts/generate-handler/generateHandler.js
@@ -87,11 +87,7 @@ try {
 
   // Errors
   schema.errors.forEach((error) => {
-    renderAndSave(
-      'error-class.ejs',
-      `../../handlers/${schema.domainName}/${schema.apiVerb}/gen/errors/${error.errorName}.ts`,
-      error,
-    );
+    renderAndSave('error-class.ejs', `../../handlers/${schema.domainName}/errors/gen/${error.errorName}.ts`, error);
   });
 
   console.log('TypeScript files generated successfully.');

--- a/backend/src/scripts/generate-handler/templates/handler-class.ejs
+++ b/backend/src/scripts/generate-handler/templates/handler-class.ejs
@@ -6,7 +6,7 @@ import { <%= handlerName %>Payload, } from '@shared/api/gen/<%= domainName %>/ty
 
 import { Abstract<%= handlerName %>Handler } from './gen/Abstract<%= handlerName %>Handler';
 <% errors.forEach(function(error, index) { %>
-import { <%= error.errorName %> } from './gen/errors/<%= error.errorName %>';<% }); %>
+import { <%= error.errorName %> } from '../<%= domainName %>/gen/errors/<%= error.errorName %>';<% }); %>
 
 export class <%= handlerName %>Handler extends Abstract<%= handlerName %>Handler {
   protected async getResult(payload: <%= handlerName %>Payload) {


### PR DESCRIPTION
### Description

Moving it back to a shared folder under the domain as they are used in other places separate to the specific api handler