### PR TITLE
feat: regen user-session after cookies clear

### DIFF
--- a/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
+++ b/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
@@ -1,7 +1,10 @@
 import { apiTestNoCookie } from '@tests/helpers/apiTest';
 import { shutDownServer } from '@tests/helpers/shutDownServer';
+import { mockGetSessionIdByUsername } from '@tests/mocks/db-mocks/users-sessions/mocks';
+import { mockUserRepositoryGetPasswordSuccess } from '@tests/mocks/userRepositoryMocks';
 
 import {
+  mockMySqlDeleteSuccess,
   mockMySqlInsertSuccess,
   mockMySqlSelectSuccess,
   mockMySqlSelectSuccessWithNoRows,
@@ -10,7 +13,9 @@ import {
 describe('signin', () => {
   it('should authenticate the user successfully with correct credentials', async () => {
     mockMySqlInsertSuccess();
-    mockMySqlSelectSuccess();
+    mockMySqlDeleteSuccess();
+    mockGetSessionIdByUsername(1, 'session-1');
+    mockUserRepositoryGetPasswordSuccess();
 
     const res = await apiTestNoCookie('/api/users.signin', {
       username: 'testuser',

--- a/backend/src/handlers/users/signin/UsersSigninHandler.ts
+++ b/backend/src/handlers/users/signin/UsersSigninHandler.ts
@@ -51,18 +51,18 @@ class UsersSigninHandler extends AbstractUsersSigninHandler {
       // This is when their is a session already (specifically when they were just in incognito)
       // TODO: need to work out what to actually do here with deleting a session when they have one..
       if (sessionIdOrError.isOk()) {
-        const deleteRes = await UserRepository.deleteUserSession(userId);
+        const deleteUserSessionOrError = await UserRepository.deleteUserSession(userId);
 
-        if (deleteRes.isError()) {
-          Logger.error(deleteRes.getError().code);
-          return new ResultError(deleteRes.getError());
+        if (deleteUserSessionOrError.isError()) {
+          Logger.error(deleteUserSessionOrError.getError().code);
+          return new ResultError(deleteUserSessionOrError.getError());
         }
       }
 
-      const res = await UserRepository.createUserSession(userId, req.session.id);
-      if (res.isError()) {
-        Logger.error(res.getError().code);
-        return new ResultError(res.getError());
+      const createUserSessionOrError = await UserRepository.createUserSession(userId, req.session.id);
+      if (createUserSessionOrError.isError()) {
+        Logger.error(createUserSessionOrError.getError().code);
+        return new ResultError(createUserSessionOrError.getError());
       }
     }
 

--- a/backend/src/handlers/users/signin/UsersSigninHandler.ts
+++ b/backend/src/handlers/users/signin/UsersSigninHandler.ts
@@ -46,6 +46,19 @@ class UsersSigninHandler extends AbstractUsersSigninHandler {
       req.session.username = username;
       req.session.authenticated = true;
 
+      const sessionIdOrError = await UserRepository.getSessionIdByUserId(userId);
+
+      // This is when their is a session already (specifically when they were just in incognito)
+      // TODO: need to work out what to actually do here with deleting a session when they have one..
+      if (sessionIdOrError.isOk()) {
+        const deleteRes = await UserRepository.deleteUserSession(userId);
+
+        if (deleteRes.isError()) {
+          Logger.error(deleteRes.getError().code);
+          return new ResultError(deleteRes.getError());
+        }
+      }
+
       const res = await UserRepository.createUserSession(userId, req.session.id);
       if (res.isError()) {
         Logger.error(res.getError().code);

--- a/backend/src/tests/mocks/db-mocks/users-sessions/mocks.ts
+++ b/backend/src/tests/mocks/db-mocks/users-sessions/mocks.ts
@@ -1,0 +1,13 @@
+import { RowDataPacket } from 'mysql2/promise';
+
+import { ResultSuccess } from '@infra/Result';
+
+import { MySqLInstance } from '../../../../db/my-sql';
+
+export const mockGetSessionIdByUsername = (userId: number, sessionId: string) => {
+  jest
+    .spyOn(MySqLInstance, 'select')
+    .mockImplementation(
+      async () => await new ResultSuccess([{ user_id: userId, session_id: sessionId }] as RowDataPacket[]),
+    );
+};

--- a/backend/src/tests/mocks/dbMocks.ts
+++ b/backend/src/tests/mocks/dbMocks.ts
@@ -20,6 +20,10 @@ export const mockMySqlInsertSuccess = () => {
   jest.spyOn(MySqLInstance, 'insert').mockImplementation(async () => await Result.success());
 };
 
+export const mockMySqlDeleteSuccess = () => {
+  jest.spyOn(MySqLInstance, 'delete').mockImplementation(async () => await Result.success());
+};
+
 export const mockMySqlSelectError = (table: string) => {
   jest.spyOn(MySqLInstance, 'select').mockImplementation(async () => await new ResultError(new DBSelectError(table)));
 };
@@ -29,7 +33,7 @@ export const mockMySqlSelectSuccess = () => {
     .spyOn(MySqLInstance, 'select')
     .mockImplementation(
       async () =>
-        await new ResultSuccess([{ user_id: 1000, username: 'testuser', password: 'testpassword' }] as RowDataPacket[])
+        await new ResultSuccess([{ user_id: 1000, username: 'testuser', password: 'testpassword' }] as RowDataPacket[]),
     );
 };
 

--- a/backend/src/tests/mocks/userRepositoryMocks.ts
+++ b/backend/src/tests/mocks/userRepositoryMocks.ts
@@ -1,0 +1,7 @@
+import { ResultSuccess } from '@infra/Result';
+
+import { UserRepository } from '../../users/UserRepository';
+
+export const mockUserRepositoryGetPasswordSuccess = () => {
+  jest.spyOn(UserRepository, 'getPassword').mockImplementation(async () => await new ResultSuccess('testpassword'));
+};

--- a/backend/src/users/UserRepository.ts
+++ b/backend/src/users/UserRepository.ts
@@ -80,7 +80,6 @@ export class UserRepository {
     const res = await DB.insert('users_sessions', ['user_id', 'session_id'], [user_id, sessionId]);
 
     if (res.isError()) {
-      console.log(res.getError());
       return new ResultError(res.getError());
     }
     return Result.success();

--- a/backend/src/users/UserRepository.ts
+++ b/backend/src/users/UserRepository.ts
@@ -85,4 +85,27 @@ export class UserRepository {
     }
     return Result.success();
   }
+
+  static async deleteUserSession(user_id: number): Promise<Result<void>> {
+    const res = await DB.delete('users_sessions', ['user_id'], [user_id]);
+    if (res.isError()) {
+      return new ResultError(res.getError());
+    }
+    return Result.success();
+  }
+
+  static async getSessionIdByUserId(user_id: number): Promise<Result<string>> {
+    const userOrError = await DB.select('users_sessions', ['user_id'], [user_id]);
+
+    if (userOrError.isError()) {
+      return new ResultError(userOrError.getError());
+    }
+
+    if (userOrError.getValue().length === 0) {
+      return new ResultError(new UsernameNotFoundError());
+    }
+    const sessionId = userOrError.getValue()[0].session_id;
+
+    return new ResultSuccess(sessionId);
+  }
 }


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

When a user goes to sign in again after clearing their cookies (or incognito) and they had a session stored, we need to delete it out and save the new one

### How to test

Tests should pass and everything should work as before

### Task

[CU-86cv9v97w](https://app.clickup.com/t/86cv9v97w)
 
### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests
- [x] Added comments

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
