### PR TITLE
feat: add game service

### DIFF
--- a/backend/src/game-lobby-service/game-lobby/GameLobby.ts
+++ b/backend/src/game-lobby-service/game-lobby/GameLobby.ts
@@ -1,3 +1,4 @@
+import { GameService } from '../../game-service/GameService';
 import { PokerTable } from '../../game/PokerTable';
 
 type PokerTablesRecord = Record<string, PokerTable>;
@@ -8,6 +9,10 @@ type PokerTablesRecord = Record<string, PokerTable>;
 export class GameLobby {
   // TODO: This would be a database eventually
   private pokerTables: PokerTablesRecord = {};
+
+  constructor() {
+    GameService.initialize();
+  }
 
   public addPokerTable(pokerTable: PokerTable) {
     this.pokerTables[pokerTable.getName()] = pokerTable;

--- a/backend/src/game-lobby-service/game-lobby/GameLobby.ts
+++ b/backend/src/game-lobby-service/game-lobby/GameLobby.ts
@@ -1,4 +1,3 @@
-import { GameService } from '../../game-service/GameService';
 import { PokerTable } from '../../game/PokerTable';
 
 type PokerTablesRecord = Record<string, PokerTable>;
@@ -9,10 +8,6 @@ type PokerTablesRecord = Record<string, PokerTable>;
 export class GameLobby {
   // TODO: This would be a database eventually
   private pokerTables: PokerTablesRecord = {};
-
-  constructor() {
-    GameService.initialize();
-  }
 
   public addPokerTable(pokerTable: PokerTable) {
     this.pokerTables[pokerTable.getName()] = pokerTable;

--- a/backend/src/game-service/GameService.ts
+++ b/backend/src/game-service/GameService.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from 'events';
+
+import { ResultError } from '@infra/Result';
+import { GameEvent } from '@shared/websockets/game/types/GameEvents';
+
+import { Dealer } from '../game/Dealer';
+import { Player } from '../game/Player';
+import { PokerTable } from '../game/PokerTable';
+import { Rooms } from '../sockets/Rooms';
+import { Sockets } from '../sockets/Sockets';
+import { UserRepository } from '../users/UserRepository';
+import { Logger } from '../utils/Logger';
+
+const debug = Logger.newDebugger('APP:GameService');
+
+export class GameService {
+  public static eventEmitter = new EventEmitter();
+
+  // Initializes any necessary listeners or setup required for the Dealer
+  public static initialize() {
+    GameService.eventEmitter.on('playerJoined', GameService.onPlayerJoined);
+  }
+
+  // Notifies when a player is added and starts game if the table is ready
+  public static onPlayerJoined(pokerTable: PokerTable, player: Player, seatNumber: number) {
+    // Emit event to all clients connected that a player has sat down
+    const event = 'player_joined';
+    const playerJoinedEventPayload = {
+      username: player.getUsername(),
+      seatNumber: seatNumber,
+    };
+
+    const sendEvents = Rooms.sendEventToRoom(pokerTable.getName(), event, playerJoinedEventPayload);
+
+    if (sendEvents.isError()) {
+      debug(sendEvents.getError());
+      return new ResultError(sendEvents.getError());
+    }
+
+    // TODO: will eventually have this be from its own api method "player is ready"
+    if (pokerTable.isPokerTableReady()) {
+      GameService.startGame(pokerTable);
+    }
+  }
+
+  public static async startGame(pokerTable: PokerTable) {
+    const event = GameEvent.START_GAME;
+    const payload = { tableName: pokerTable.getName() };
+
+    const sendEvents = Rooms.sendEventToRoom(pokerTable.getName(), event, payload);
+
+    if (sendEvents.isError()) {
+      throw sendEvents.getError();
+    }
+
+    Dealer.newGame(pokerTable);
+
+    Dealer.dealCards(pokerTable);
+
+    const seats = pokerTable.getSeats();
+
+    seats.forEach(async (seat) => {
+      const player = seat.getPlayer();
+      if (player) {
+        const playerSessionIdOrError = await UserRepository.getSessionIdByUserId(player.getUserId());
+        if (playerSessionIdOrError.isError()) {
+          debug(playerSessionIdOrError.getError());
+          throw playerSessionIdOrError.getError();
+        }
+
+        const dealCardsEvent = GameEvent.DEAL_CARDS;
+
+        const payload = { cards: player.getCards() };
+
+        Sockets.sendEventToClient(playerSessionIdOrError.getValue(), dealCardsEvent, payload);
+      }
+    });
+  }
+}

--- a/backend/src/game-service/GameService.ts
+++ b/backend/src/game-service/GameService.ts
@@ -18,6 +18,7 @@ export class GameService {
 
   // Initializes any necessary listeners or setup required for the Dealer
   public static initialize() {
+    console.log('GameService initialized');
     GameService.eventEmitter.on('playerJoined', GameService.onPlayerJoined);
   }
 

--- a/backend/src/game-service/GameService.ts
+++ b/backend/src/game-service/GameService.ts
@@ -18,7 +18,6 @@ export class GameService {
 
   // Initializes any necessary listeners or setup required for the Dealer
   public static initialize() {
-    console.log('GameService initialized');
     GameService.eventEmitter.on('playerJoined', GameService.onPlayerJoined);
   }
 

--- a/backend/src/game-service/index.ts
+++ b/backend/src/game-service/index.ts
@@ -1,0 +1,5 @@
+import { GameService } from './GameService';
+
+// TODO: Seed / hardcode for now until we are working with a DB
+GameService.initialize();
+export { GameService };

--- a/backend/src/game-service/index.ts
+++ b/backend/src/game-service/index.ts
@@ -1,5 +1,4 @@
 import { GameService } from './GameService';
 
-// TODO: Seed / hardcode for now until we are working with a DB
 GameService.initialize();
 export { GameService };

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -1,5 +1,6 @@
 import { Result, ResultSuccess } from '@infra/Result';
 
+import { GameService } from '../game-service/GameService';
 import { SeatNotFoundError } from '../handlers/poker-tables/errors/SeatNotFoundError';
 import { PlayerAlreadySeatedError } from '../handlers/poker-tables/errors/gen/PlayerAlreadySeatedError';
 import { PlayerNotFoundAtPokerTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError';
@@ -50,6 +51,9 @@ export class PokerTable {
           return Result.error(new SeatTakenError());
         } else {
           seat.assignPlayer(player);
+
+          GameService.eventEmitter.emit('playerJoined', this, player, seatNumber);
+
           return Result.success();
         }
       }

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -1,6 +1,6 @@
 import { Result, ResultSuccess } from '@infra/Result';
 
-import { GameService } from '../game-service/GameService';
+import { GameService } from '../game-service';
 import { SeatNotFoundError } from '../handlers/poker-tables/errors/SeatNotFoundError';
 import { PlayerAlreadySeatedError } from '../handlers/poker-tables/errors/gen/PlayerAlreadySeatedError';
 import { PlayerNotFoundAtPokerTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError';

--- a/backend/src/shared/websockets/game/types/GameEvents.ts
+++ b/backend/src/shared/websockets/game/types/GameEvents.ts
@@ -1,11 +1,19 @@
+import { Card } from '../../../game/types/Card';
+
 export enum GameEvent {
   START_GAME = 'start_game',
+  DEAL_CARDS = 'deal_cards',
 }
 
 export type StartGameEvent = {
   tableName: string;
 };
 
+export type DealCardsEvent = {
+  cards: Card[];
+};
+
 export interface GameEvents {
   start_game: (payload: StartGameEvent) => void;
+  deal_cards: (payload: DealCardsEvent) => void;
 }

--- a/backend/src/tests/helpers/createPokerTableWithPlayers.ts
+++ b/backend/src/tests/helpers/createPokerTableWithPlayers.ts
@@ -1,5 +1,6 @@
 import { createPokerTable } from '@tests/helpers/createPokerTable';
 import { mockSendEventToRoomSuccess } from '@tests/mocks/roomMocks';
+import { mockMySqlSelectSessionSuccess } from '@tests/mocks/sessionMocks';
 
 import { Player } from '../../game/Player';
 
@@ -13,6 +14,7 @@ export function createPokerTableWithPlayers(tableName: string, numberOfSeats: nu
     const user = new Player(1234 + seatNumber, 'a' + seatNumber);
 
     players.push(user);
+    mockMySqlSelectSessionSuccess(user.getUsername());
     const res = pokerTable.addPlayer(seatNumber, user);
 
     if (res.isError()) {

--- a/backend/src/tests/helpers/createPokerTableWithPlayers.ts
+++ b/backend/src/tests/helpers/createPokerTableWithPlayers.ts
@@ -1,11 +1,13 @@
 import { createPokerTable } from '@tests/helpers/createPokerTable';
 import { mockSendEventToRoomSuccess } from '@tests/mocks/roomMocks';
 import { mockMySqlSelectSessionSuccess } from '@tests/mocks/sessionMocks';
+import { mockSendEventToSocketSuccess } from '@tests/mocks/socketMocks';
 
 import { Player } from '../../game/Player';
 
 export function createPokerTableWithPlayers(tableName: string, numberOfSeats: number) {
   mockSendEventToRoomSuccess();
+  mockSendEventToSocketSuccess();
   const pokerTable = createPokerTable(tableName, numberOfSeats);
   const players: Player[] = [];
 

--- a/backend/src/tests/mocks/socketMocks.ts
+++ b/backend/src/tests/mocks/socketMocks.ts
@@ -1,0 +1,12 @@
+import { Result, ResultError } from '@infra/Result';
+
+import { Sockets } from '../../sockets/Sockets';
+import { SocketNotFoundError } from '../../sockets/errors/SocketErrors';
+
+export const mockSendEventToSocketSuccess = () => {
+  jest.spyOn(Sockets, 'sendEventToClient').mockImplementation(() => Result.success());
+};
+
+export const mockSendEventToSocketError = () => {
+  jest.spyOn(Sockets, 'sendEventToClient').mockImplementation(() => new ResultError(new SocketNotFoundError()));
+};

--- a/backend/src/users/UserService.ts
+++ b/backend/src/users/UserService.ts
@@ -1,8 +1,11 @@
 import { Result, ResultError, ResultSuccess } from '@infra/Result';
 
 import { PasswordInvalidError } from '../handlers/users/errors/gen/PasswordInvalidError';
+import { Logger } from '../utils/Logger';
 import { User } from './User';
 import { UserRepository } from './UserRepository';
+
+const debug = Logger.newDebugger('APP:UserService');
 
 // This file contains the UserService class which is responsible for managing users.
 export class UserService {
@@ -39,5 +42,16 @@ export class UserService {
     }
 
     return new ResultSuccess(userOrError.getValue());
+  }
+
+  public static async getSessionId(user: User) {
+    const sessionIdOrError = await UserRepository.getSessionIdByUserId(user.getUserId());
+
+    if (sessionIdOrError.isError()) {
+      debug(sessionIdOrError.getError());
+      throw sessionIdOrError.getError();
+    }
+
+    return sessionIdOrError.getValue();
   }
 }


### PR DESCRIPTION
### Description

This PR adds the game service, moving Room and Socket calls from the Join handler. 

A game starts after 2 people have joined the table (will eventually decouple this and have a button for them to say they are ready). The dealer then deals random cards and the GameService gets notified and sends the cards out on the appropriate sockets

### How to test

<!--- Steps on how to test this change  --->

1. Open the client in browser and incognito
2. Go to the `ws` in the dev tools and refresh
3. Sign in with two players (richard : testpassword, thomas : testpassword)
4. Join the table on each
5. Note that each player is dealt cards 

### Task

[CU-86cu6pajh](https://app.clickup.com/t/86cu6pajh) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
