### PR TITLE
feat: seat to act and send notification

### DIFF
--- a/backend/src/game-service/GameService.ts
+++ b/backend/src/game-service/GameService.ts
@@ -56,6 +56,8 @@ export class GameService {
     }
 
     this.dealCards(pokerTable);
+
+    this.notifyPlayerToAct(pokerTable);
   }
 
   private static async dealCards(pokerTable: PokerTable) {
@@ -81,5 +83,30 @@ export class GameService {
         }
       }
     });
+  }
+
+  private static async notifyPlayerToAct(pokerTable: PokerTable) {
+    const game = pokerTable.getGame();
+    if (!game) {
+      throw new Error('Game not found');
+    }
+
+    const seatToAct = game.getGameState().getSeatToAct();
+    const seats = pokerTable.getSeats();
+
+    const seat = seats.find((seat) => seat.getSeatNumber() === seatToAct);
+
+    if (!seat) {
+      throw new Error(`Seat not found: ${seatToAct}`);
+    }
+
+    const event = GameEvent.SEAT_TO_ACT;
+    const payload = { seatToAct: seat.getSeatNumber() };
+
+    const sendEvents = Rooms.sendEventToRoom(pokerTable.getName(), event, payload);
+
+    if (sendEvents.isError()) {
+      throw sendEvents.getError();
+    }
   }
 }

--- a/backend/src/game/Dealer.test.ts
+++ b/backend/src/game/Dealer.test.ts
@@ -25,7 +25,6 @@ describe('Dealer', () => {
     expect(game.getGameState().getBigBlind()).toBe(2);
     expect(game.getGameState().getPot()).toBe(0);
     expect(game.getGameState().getCurrentBet()).toBe(0);
-    expect(game.getGameState().getPlayerToActIndex()).toBe(0);
     expect(game.getGameState().getRound()).toBe('pre-flop');
     expect(game.getGameState().getCommunityCards()).toEqual([]);
   });

--- a/backend/src/game/Dealer.ts
+++ b/backend/src/game/Dealer.ts
@@ -7,6 +7,18 @@ export class Dealer {
     const bigBlind = smallBlind * 2;
 
     pokerTable.addGame(new Game(pokerTable.getDealerPosition(), smallBlind, bigBlind));
+
+    const playerCount = pokerTable.getPlayerCount();
+
+    // Dealer position is always the first player to act when there are 3 or less players
+    if (playerCount > 3) {
+      pokerTable
+        .getGame()
+        ?.getGameState()
+        .updateSeatToAct(pokerTable.getDealerPosition() + 3);
+    } else {
+      pokerTable.getGame()?.getGameState().updateSeatToAct(pokerTable.getDealerPosition());
+    }
   }
 
   public static dealCards(pokerTable: PokerTable) {

--- a/backend/src/game/Game.test.ts
+++ b/backend/src/game/Game.test.ts
@@ -14,7 +14,6 @@ describe('Game', () => {
     expect(game.getGameState().getBigBlind()).toBe(20);
     expect(game.getGameState().getPot()).toBe(0);
     expect(game.getGameState().getCurrentBet()).toBe(0);
-    expect(game.getGameState().getPlayerToActIndex()).toBe(0);
     expect(game.getGameState().getRound()).toBe('pre-flop');
     expect(game.getGameState().getCommunityCards()).toEqual([]);
   });

--- a/backend/src/game/GameState.test.ts
+++ b/backend/src/game/GameState.test.ts
@@ -16,7 +16,6 @@ describe('GameState', () => {
     expect(gameState.getBigBlind()).toBe(20);
     expect(gameState.getPot()).toBe(0);
     expect(gameState.getCurrentBet()).toBe(0);
-    expect(gameState.getPlayerToActIndex()).toBe(0);
     expect(gameState.getRound()).toBe(Round.preFlop);
     expect(gameState.getCommunityCards()).toEqual([]);
   });
@@ -45,8 +44,8 @@ describe('GameState', () => {
   });
 
   it('updates the current player index', async () => {
-    gameState.updateCurrentPlayerIndex(2);
-    expect(gameState.getPlayerToActIndex()).toBe(2);
+    gameState.updateSeatToAct(2);
+    expect(gameState.getSeatToAct()).toBe(2);
   });
 
   it('updates the round', async () => {

--- a/backend/src/game/GameState.ts
+++ b/backend/src/game/GameState.ts
@@ -16,7 +16,7 @@ export class GameState {
   private bigBlind: number;
   private pot: number;
   private currentBet: number;
-  private playerToActIndex: number;
+  private seatToAct: number;
   private roundState: Round;
   private communityCards: Card[];
 
@@ -27,7 +27,7 @@ export class GameState {
 
     this.pot = 0;
     this.currentBet = 0;
-    this.playerToActIndex = 0;
+    this.seatToAct = 0;
     this.roundState = Round.preFlop;
     this.communityCards = [];
   }
@@ -46,8 +46,8 @@ export class GameState {
     this.currentBet = currentBet;
   }
 
-  public updateCurrentPlayerIndex(playerToActIndex: number) {
-    this.playerToActIndex = playerToActIndex;
+  public updateSeatToAct(seatToAct: number) {
+    this.seatToAct = seatToAct;
   }
 
   public getRound() {
@@ -78,8 +78,8 @@ export class GameState {
     return this.currentBet;
   }
 
-  public getPlayerToActIndex() {
-    return this.playerToActIndex;
+  public getSeatToAct() {
+    return this.seatToAct;
   }
 
   public getCommunityCards() {

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -31,7 +31,7 @@ export class PokerTable {
     }
     this.seats = seatsArray;
 
-    this.dealerPosition = Math.floor(Math.random() * numberOfSeats);
+    this.dealerPosition = Math.floor(Math.random() * numberOfSeats + 1);
   }
 
   public static createPokerTable(pokerTableName: string, numberOfSeats: number): Result<PokerTable> {
@@ -72,7 +72,7 @@ export class PokerTable {
     return Result.error(new PlayerNotFoundAtPokerTableError());
   }
 
-  public addGame(game: Game) {
+  public addGame(game: Game): void {
     this.game = game;
   }
 
@@ -110,5 +110,15 @@ export class PokerTable {
 
   public getDealerPosition(): number {
     return this.dealerPosition;
+  }
+
+  public getPlayerCount(): number {
+    let count = 0;
+    for (const seat of this.seats) {
+      if (seat.isSeatTaken()) {
+        count++;
+      }
+    }
+    return count;
   }
 }

--- a/backend/src/shared/websockets/game/types/GameEvents.ts
+++ b/backend/src/shared/websockets/game/types/GameEvents.ts
@@ -3,6 +3,7 @@ import { Card } from '../../../game/types/Card';
 export enum GameEvent {
   START_GAME = 'start_game',
   DEAL_CARDS = 'deal_cards',
+  SEAT_TO_ACT = 'seat_to_act',
 }
 
 export type StartGameEvent = {
@@ -16,4 +17,5 @@ export type DealCardsEvent = {
 export interface GameEvents {
   start_game: (payload: StartGameEvent) => void;
   deal_cards: (payload: DealCardsEvent) => void;
+  seat_to_act: (payload: { seatToAct: number }) => void;
 }


### PR DESCRIPTION
### Description

This PR adds setting the "seat to act" and sends out a notification to the table

### How to test

<!--- Steps on how to test this change  --->

1. Join the table with two players
2. Look at the websocket and note a `seat_to_act` event

### Task

[CU-86cvbdgw8 ](https://app.clickup.com/t/86cvbdgw8)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
