### PR TITLE
fix: show only one leave seat button

### DIFF
--- a/backend/test-requests/pokerTablesJoin.http
+++ b/backend/test-requests/pokerTablesJoin.http
@@ -4,7 +4,7 @@
 
 ### !!!! This will error with `not_authed` if you have not used the `signin.http` test-request first
 
-POST http://localhost:3000/api/poker-tables.join
+POST http://localhost:3000/api/actions/poker-tables.join
 content-type: application/json
 
 {

--- a/frontend/src/components/PokerTable/Seat/Seat.tsx
+++ b/frontend/src/components/PokerTable/Seat/Seat.tsx
@@ -70,7 +70,7 @@ export default function Seat({ seatNumber, username, chipCount, cards, isActingS
       >
         {renderSeatDisplay()}
       </button>
-      <button onClick={playerLeave}>Leave Seat {seatNumber}</button>
+      {myUsername === username ? <button onClick={playerLeave}>Leave seat</button> : null}
     </div>
   );
 }


### PR DESCRIPTION
### Description

We were showing buttons for both seats to leave them. Now that we have a way to distinguish that it's the player's seat, we can hide the other
<img width="794" alt="Screenshot 2024-05-13 at 8 52 34 am" src="https://github.com/richardaspinall/poker-react-node/assets/15721687/40c223ff-3f62-42bb-95a5-eda2ae5316a5">


### Task

[CU-86cueaaan](https://app.clickup.com/t/86cueaaan) 

### Checklist

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
