### PR TITLE
feat: hide action buttons

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 npm run unit_tests
 npm run api_tests
+npm run fe_tests

--- a/frontend/src/components/PokerTable/Actions/Actions.test.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.test.tsx
@@ -3,27 +3,54 @@ import { render, screen } from '@testing-library/react';
 import Actions from './Actions';
 
 describe('Actions Component', () => {
-  it('renders Fold button', () => {
-    render(<Actions isMyTurn={true} />);
-    const foldButton = screen.getByRole('button', { name: 'Fold' });
-    expect(foldButton).toBeVisible();
-  });
+  describe('when players turn', () => {
+    it('renders Fold button', () => {
+      render(<Actions isMyTurn={true} />);
+      const foldButton = screen.getByRole('button', { name: 'Fold' });
+      expect(foldButton).toBeVisible();
+    });
 
-  it('renders Check button', () => {
-    render(<Actions isMyTurn={true} />);
-    const checkButton = screen.getByRole('button', { name: 'Fold' });
-    expect(checkButton).toBeVisible();
-  });
+    it('renders Check button', () => {
+      render(<Actions isMyTurn={true} />);
+      const checkButton = screen.getByRole('button', { name: 'Fold' });
+      expect(checkButton).toBeVisible();
+    });
 
-  it('renders Call button', () => {
-    render(<Actions isMyTurn={true} />);
-    const callButton = screen.getByRole('button', { name: 'Call' });
-    expect(callButton).toBeVisible();
-  });
+    it('renders Call button', () => {
+      render(<Actions isMyTurn={true} />);
+      const callButton = screen.getByRole('button', { name: 'Call' });
+      expect(callButton).toBeVisible();
+    });
 
-  it('renders Bet button', () => {
-    render(<Actions isMyTurn={true} />);
-    const betButton = screen.getByRole('button', { name: 'Bet' });
-    expect(betButton).toBeVisible();
+    it('renders Bet button', () => {
+      render(<Actions isMyTurn={true} />);
+      const betButton = screen.getByRole('button', { name: 'Bet' });
+      expect(betButton).toBeVisible();
+    });
+  });
+  describe('when not players turn', () => {
+    it('does not render Fold button', () => {
+      render(<Actions isMyTurn={false} />);
+      const foldButton = screen.queryByRole('button', { name: 'Fold' });
+      expect(foldButton).not.toBeInTheDocument();
+    });
+
+    it('does not render Check button', () => {
+      render(<Actions isMyTurn={false} />);
+      const checkButton = screen.queryByRole('button', { name: 'Check' });
+      expect(checkButton).not.toBeInTheDocument();
+    });
+
+    it('does not render Call button', () => {
+      render(<Actions isMyTurn={false} />);
+      const callButton = screen.queryByRole('button', { name: 'Call' });
+      expect(callButton).not.toBeInTheDocument();
+    });
+
+    it('does not render Bet button', () => {
+      render(<Actions isMyTurn={false} />);
+      const betButton = screen.queryByRole('button', { name: 'Bet' });
+      expect(betButton).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/PokerTable/Actions/Actions.test.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.test.tsx
@@ -4,25 +4,25 @@ import Actions from './Actions';
 
 describe('Actions Component', () => {
   it('renders Fold button', () => {
-    render(<Actions />);
+    render(<Actions isMyTurn={true} />);
     const foldButton = screen.getByRole('button', { name: 'Fold' });
     expect(foldButton).toBeVisible();
   });
 
   it('renders Check button', () => {
-    render(<Actions />);
+    render(<Actions isMyTurn={true} />);
     const checkButton = screen.getByRole('button', { name: 'Fold' });
     expect(checkButton).toBeVisible();
   });
 
   it('renders Call button', () => {
-    render(<Actions />);
+    render(<Actions isMyTurn={true} />);
     const callButton = screen.getByRole('button', { name: 'Call' });
     expect(callButton).toBeVisible();
   });
 
   it('renders Bet button', () => {
-    render(<Actions />);
+    render(<Actions isMyTurn={true} />);
     const betButton = screen.getByRole('button', { name: 'Bet' });
     expect(betButton).toBeVisible();
   });

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -1,26 +1,30 @@
-type ActionsProps = {};
+type ActionsProps = {
+  isMyTurn: boolean;
+};
 
-function Actions({}: ActionsProps) {
+function Actions({ isMyTurn }: ActionsProps) {
   return (
     <div id="player-actions">
       {/* <div className="slidecontainer">
         <input type="range" min="0" max="10000" value="1000" className="slider" id="myRange"></input>
         <input id="bet-input" value="1000"></input>
       </div> */}
-      <div>
-        <button className="action-buttons" id="fold-action-button" aria-label="Fold">
-          Fold
-        </button>
-        <button className="action-buttons" id="check-action-button" aria-label="Check">
-          Check
-        </button>
-        <button className="action-buttons" id="call-action-button" aria-label="Call">
-          Call
-        </button>
-        <button className="action-buttons" id="raise-action-button" aria-label="Bet">
-          Bet
-        </button>
-      </div>
+      {isMyTurn && (
+        <div>
+          <button className="action-buttons" id="fold-action-button" aria-label="Fold">
+            Fold
+          </button>
+          <button className="action-buttons" id="check-action-button" aria-label="Check">
+            Check
+          </button>
+          <button className="action-buttons" id="call-action-button" aria-label="Call">
+            Call
+          </button>
+          <button className="action-buttons" id="raise-action-button" aria-label="Bet">
+            Bet
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/PokerTable/PokerTable.tsx
+++ b/frontend/src/components/PokerTable/PokerTable.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { selectActingSeat, selectHoleCards, selectSeats } from '../../store/selectors.ts';
+import { selectActingSeat, selectHoleCards, selectMyUsername, selectSeats } from '../../store/selectors.ts';
 import { AppDispatch } from '../../store/store.tsx';
 import Actions from './Actions/Actions';
 import Board from './Board/Board';
@@ -23,6 +23,8 @@ export function PokerTable() {
   const seats = useSelector(selectSeats);
   const holeCards = useSelector(selectHoleCards);
   const actingSeat = useSelector(selectActingSeat);
+  const myUsername = useSelector(selectMyUsername);
+  const isMyTurn = seats.value?.find((seat) => seat.seatNumber === actingSeat)?.username === myUsername;
 
   return (
     <>
@@ -33,14 +35,15 @@ export function PokerTable() {
           <Seat
             key={seat.seatNumber}
             seatNumber={seat.seatNumber}
-            username={seat.username}
+            myUsername={myUsername}
+            seatUsername={seat.username}
             chipCount={1000}
             cards={holeCards.value}
             isActingSeat={seat.seatNumber === actingSeat}
           />
         ))}
       </div>
-      <Actions />
+      <Actions isMyTurn={isMyTurn} />
     </>
   );
 }

--- a/frontend/src/components/PokerTable/Seat/Seat.tsx
+++ b/frontend/src/components/PokerTable/Seat/Seat.tsx
@@ -1,23 +1,27 @@
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
 
 import { Card as CardType } from '../../../../../backend/src/shared/game/types/Card';
 import { CardShortCode } from '../../../../../backend/src/shared/game/types/CardShortCode';
 import apiCall from '../../../fetch/apiCall';
-import { selectUsername } from '../../../store/selectors.ts';
 import { Card } from '../../Card/Card.tsx';
 
 type SeatProps = {
   seatNumber: number;
   chipCount: number;
-  username?: string;
+  myUsername?: string;
+  seatUsername?: string;
   cards?: CardType[];
   isActingSeat?: boolean;
 };
 
-export default function Seat({ seatNumber, username, chipCount, cards, isActingSeat }: Readonly<SeatProps>) {
-  const selfUsername = useSelector(selectUsername);
-
+export default function Seat({
+  seatNumber,
+  myUsername,
+  seatUsername,
+  chipCount,
+  cards,
+  isActingSeat,
+}: Readonly<SeatProps>) {
   const onPlayerSit = useCallback(async () => {
     const payload = { selectedSeatNumber: seatNumber };
 
@@ -40,22 +44,22 @@ export default function Seat({ seatNumber, username, chipCount, cards, isActingS
   // Define a function to render the cards if the user is in the hand
   // TODO: will need to update this to show the cards if the user is actually in the hand
   const renderSeatDisplay = () => {
-    if (selfUsername === username && cards?.[0]) {
+    if (myUsername === seatUsername && cards?.[0]) {
       return (
         <>
           <Card cardShortCode={cards[0].cardShortCode} />
           <Card cardShortCode={cards[1].cardShortCode} />
         </>
       );
-    } else if (username && cards?.[0]) {
+    } else if (seatUsername && cards?.[0]) {
       return (
         <>
           <Card cardShortCode={CardShortCode.FaceDownCard} />
           <Card cardShortCode={CardShortCode.FaceDownCard} />
         </>
       );
-    } else if (username) {
-      return username;
+    } else if (seatUsername) {
+      return seatUsername;
     }
     return 'Empty';
   };
@@ -70,7 +74,7 @@ export default function Seat({ seatNumber, username, chipCount, cards, isActingS
       >
         {renderSeatDisplay()}
       </button>
-      {selfUsername === username ? <button onClick={playerLeave}>Leave seat</button> : null}
+      {myUsername === seatUsername ? <button onClick={playerLeave}>Leave seat</button> : null}
     </div>
   );
 }

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -6,26 +6,26 @@ export const selectSeats = createSelector(
   (state: RootState) => state.seats, // This is the input selector
   (seats) => {
     return { ...seats };
-  }
+  },
 );
 
-export const selectUsername = createSelector(
+export const selectMyUsername = createSelector(
   (state: RootState) => state.userProfile, // This is the input selector
   (userProfile) => {
     return userProfile.value?.username;
-  }
+  },
 );
 
 export const selectHoleCards = createSelector(
   (state: RootState) => state.holeCards, // This is the input selector
   (holeCards) => {
     return { ...holeCards };
-  }
+  },
 );
 
 export const selectActingSeat = createSelector(
   (state: RootState) => state.seatToAct.value, // This is the input selector
   (seatToAct) => {
     return seatToAct;
-  }
+  },
 );


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

This PR adds hiding or showing the action buttons depending on who's turn it is

### How to test

<!--- Steps on how to test this change  --->

1. Open and join the table by two players
2. Note only the player with turn to act ring has the buttons

### Task

[CU-86cvmb1wk ](https://app.clickup.com/t/86cvmb1wk)

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests
- [x] Added learning objectives to clickup task

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
