### PR TITLE
feat: implement fold action and turn logic

### DIFF
--- a/backend/src/db/my-sql/MySql.ts
+++ b/backend/src/db/my-sql/MySql.ts
@@ -39,7 +39,6 @@ class MySql {
 
       return new ResultSuccess(rows);
     } catch (error) {
-      console.log('ERROR:', error);
       return new ResultError(new DBSelectError(table));
     }
   }

--- a/backend/src/game/Dealer.test.ts
+++ b/backend/src/game/Dealer.test.ts
@@ -3,19 +3,16 @@ import { createPokerTableWithPlayers } from '@tests/helpers/createPokerTableWith
 import { Dealer } from './Dealer';
 import { Game } from './Game';
 import { PokerTable } from './PokerTable';
-import { Player } from './Player';
 
 describe('Dealer', () => {
   let newPokerTable: PokerTable;
-  let newPlayers: Player[];
 
   beforeEach(() => {
     const pokerTableName = 'table_1';
-    const numberOfSeats = 2;
-    const { pokerTable, players } = createPokerTableWithPlayers(pokerTableName, numberOfSeats);
+    const numberOfSeats = 3;
+    const { pokerTable } = createPokerTableWithPlayers(pokerTableName, numberOfSeats);
 
     newPokerTable = pokerTable;
-    newPlayers = players;
   });
 
   it('should create a new game', () => {
@@ -47,7 +44,7 @@ describe('Dealer', () => {
   });
 
   describe('foldPlayer', () => {
-    it('should return empty cards for folded player', () => {
+    it.only('should return empty cards for folded player', () => {
       let player;
       const game = newPokerTable.getGame() as Game;
       const seatToAct = game.getGameState().getSeatToAct();
@@ -57,9 +54,11 @@ describe('Dealer', () => {
       seats.forEach((seat) => {
         if (seat.getSeatNumber() === seatToAct) {
           player = seat.getPlayer();
-          if (player){
-            Dealer.foldCards(newPokerTable, player.getUserId());            
+          if (player) {
+            Dealer.foldCards(newPokerTable, player.getUserId());
             const playerCards = player.getCards();
+            // TODO: Fix this test new cards have been dealt after folding
+            // Fix by creating a game with 3 players
             expect(playerCards.length).toEqual(0);
           }
         }

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -78,6 +78,7 @@ export class PokerTable {
 
   public addGame(game: Game): void {
     this.game = game;
+    this.dealerPosition = game.getGameState().getDealerPosition();
   }
 
   public getGame(): Game | undefined {
@@ -120,7 +121,7 @@ export class PokerTable {
         count++;
       }
     }
-    if (count > 0){
+    if (count > 1) {
       return true;
     }
 

--- a/backend/src/handlers/games/check/gen/AbstractGamesCheckHandler.ts
+++ b/backend/src/handlers/games/check/gen/AbstractGamesCheckHandler.ts
@@ -2,17 +2,22 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { GamesCheckPayload, GamesCheckOutput } from '@shared/api/gen/games/types/GamesCheck';
 
-import { AbstractGamesCheckHandler } from './gen/AbstractGamesCheckHandler';
 
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
 import { NotActivePlayerError } from '../errors/gen/NotActivePlayerError';
+import { AbstractGamesCheckHandler } from './gen/AbstractGamesCheckHandler';
 
 export class GamesCheckHandler extends AbstractGamesCheckHandler {
   protected async getResult(payload: GamesCheckPayload) {
-    return new ResultSuccess<GamesCheckOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<GamesCheckOutput>();
   }
 }
 */

--- a/backend/src/handlers/games/errors/gen/PokerTableDoesNotExistError.ts
+++ b/backend/src/handlers/games/errors/gen/PokerTableDoesNotExistError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PokerTableDoesNotExistError extends BaseError {
   constructor() {
-    super('poker_table_does_not_exist', 'The specified poker table does not exist.');
+    super('poker_table_does_not_exist', 'Table does not exist');
   }
 }

--- a/backend/src/shared/api/gen/games/schemas/GamesCheckSchemas.ts
+++ b/backend/src/shared/api/gen/games/schemas/GamesCheckSchemas.ts
@@ -4,7 +4,6 @@ import { GamesCheckOutput, GamesCheckPayload } from '../types/GamesCheck';
 
 export const GamesCheckPayloadSchema = Joi.object<GamesCheckPayload>({
   pokerTableName: Joi.string().required(),
-  selectedSeatNumber: Joi.number().required(),
 }).unknown(false);
 
 export const GamesCheckOutputSchema = Joi.object<GamesCheckOutput>({ ok: Joi.boolean().required() }).unknown(false);

--- a/backend/src/shared/api/gen/games/types/GamesCheck.ts
+++ b/backend/src/shared/api/gen/games/types/GamesCheck.ts
@@ -2,7 +2,6 @@ import { BaseOutput } from '../../../BaseOutput';
 
 export interface GamesCheckPayload {
   pokerTableName: string;
-  selectedSeatNumber: number;
 }
 
 export interface GamesCheckOutput extends BaseOutput {

--- a/backend/src/shared/api/metadata/games_check.json
+++ b/backend/src/shared/api/metadata/games_check.json
@@ -1,48 +1,42 @@
 {
-    "handlerName": "GamesCheck",
-    "domainName": "games",
-    "apiVerb": "check",
-    "httpMethod": "post",
-    "authRequired": true,
-    "payload": {
-      "properties": [
-        {
-          "name": "pokerTableName",
-          "type": "string",
-          "required": true
-        },
-        {
-          "name": "selectedSeatNumber",
-          "type": "number",
-          "required": true
-        }
-      ]
-    },
-    "output": {
-      "properties": [
-        {
-          "name": "ok",
-          "type": "boolean",
-          "required": true
-        }
-      ]
-    },
-    "errors": [
+  "handlerName": "GamesCheck",
+  "domainName": "games",
+  "apiVerb": "check",
+  "httpMethod": "post",
+  "authRequired": true,
+  "payload": {
+    "properties": [
       {
-        "errorName": "PlayerNotFoundAtTableError",
-        "errorCode": "player_not_found_at_poker_table",
-        "message": "Player is not seated at the table"
-      },
-      {
-        "errorName": "PokerTableDoesNotExistError",
-        "errorCode": "poker_table_does_not_exist",
-        "message": "Table does not exist"
-      },
-      {
-        "errorName": "NotActivePlayerError",
-        "errorCode": "player_not_active_player",
-        "message": "Player is not active player"
+        "name": "pokerTableName",
+        "type": "string",
+        "required": true
       }
     ]
-  }
-  
+  },
+  "output": {
+    "properties": [
+      {
+        "name": "ok",
+        "type": "boolean",
+        "required": true
+      }
+    ]
+  },
+  "errors": [
+    {
+      "errorName": "PlayerNotFoundAtTableError",
+      "errorCode": "player_not_found_at_poker_table",
+      "message": "Player is not seated at the table"
+    },
+    {
+      "errorName": "PokerTableDoesNotExistError",
+      "errorCode": "poker_table_does_not_exist",
+      "message": "Table does not exist"
+    },
+    {
+      "errorName": "NotActivePlayerError",
+      "errorCode": "player_not_active_player",
+      "message": "Player is not active player"
+    }
+  ]
+}

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -1,8 +1,39 @@
+import { useCallback } from 'react';
+
+import apiCall from '../../../fetch/apiCall';
+
 type ActionsProps = {
   isMyTurn: boolean;
 };
 
 function Actions({ isMyTurn }: ActionsProps) {
+  const fold = useCallback(async () => {
+    const payload = { pokerTableName: 'table_1' };
+    const result = await apiCall.post('games.fold', payload);
+    if (!result?.ok) {
+      // Do something with the error
+      console.log(result?.error);
+    }
+  }, []);
+
+  const check = useCallback(async () => {
+    const payload = { pokerTableName: 'table_1' };
+    const result = await apiCall.post('games.check', payload);
+    if (!result?.ok) {
+      // Do something with the error
+      console.log(result?.error);
+    }
+  }, []);
+
+  const call = useCallback(async () => {
+    const payload = { pokerTableName: 'table_1' };
+    const result = await apiCall.post('games.call', payload);
+    if (!result?.ok) {
+      // Do something with the error
+      console.log(result?.error);
+    }
+  }, []);
+
   return (
     <div id="player-actions">
       {/* <div className="slidecontainer">
@@ -11,13 +42,13 @@ function Actions({ isMyTurn }: ActionsProps) {
       </div> */}
       {isMyTurn && (
         <div>
-          <button className="action-buttons" id="fold-action-button" aria-label="Fold">
+          <button className="action-buttons" id="fold-action-button" aria-label="Fold" onClick={fold}>
             Fold
           </button>
-          <button className="action-buttons" id="check-action-button" aria-label="Check">
+          <button className="action-buttons" id="check-action-button" aria-label="Check" onClick={check}>
             Check
           </button>
-          <button className="action-buttons" id="call-action-button" aria-label="Call">
+          <button className="action-buttons" id="call-action-button" aria-label="Call" onClick={call}>
             Call
           </button>
           <button className="action-buttons" id="raise-action-button" aria-label="Bet">


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

This PR hooks up the actions to the backend, and reworks the turn functionality off the back of folding to send back to the FE and update. 

### How to test

<!--- Steps on how to test this change  --->

1. Seat two players
2. Click Fold for one player

Expected: 
- New cards are dealt
- Other player's turn
![folding](https://github.com/richardaspinall/poker-react-node/assets/15721687/868e0d49-792b-4698-9a4e-28c594e9005f)


### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->

[CU-86cvve277](https://app.clickup.com/t/86cvve277) 

### Checklist

<!--- X off relevant items for this change, delete anything not relevant --->

- [x] Added / Updated unit tests

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
