### PR TITLE
fix: tidy up errors

### DIFF
--- a/backend/src/game/Dealer.ts
+++ b/backend/src/game/Dealer.ts
@@ -1,10 +1,10 @@
 import { Card } from '@shared/game/types/Card';
 
 import { GameEmitter } from '../game-emitter';
-import { GameDoesNotExist } from '../handlers/games/errors/gen/GameDoesNotExist';
-import { NotPlayersTurn } from '../handlers/games/errors/gen/NotPlayersTurn';
-import { PlayerAlreadyFolded } from '../handlers/games/errors/gen/PlayerAlreadyFolded';
-import { PlayerNotFoundAtPokerTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError';
+import { GameDoesNotExistError } from '../handlers/games/errors/gen/GameDoesNotExistError';
+import { NotPlayersTurnError } from '../handlers/games/errors/gen/NotPlayersTurnError';
+import { PlayerAlreadyFoldedError } from '../handlers/games/errors/gen/PlayerAlreadyFoldedError';
+import { PlayerNotFoundAtTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtTableError';
 import { Result } from '../infra/Result';
 import { Game } from './Game';
 import { PokerTable } from './PokerTable';
@@ -57,24 +57,24 @@ export class Dealer {
   public static foldCards(pokerTable: PokerTable, userId: number) {
     const game = pokerTable.getGame();
     if (!game) {
-      return Result.error(new GameDoesNotExist());
+      return Result.error(new GameDoesNotExistError());
     }
 
     const seats = pokerTable.getSeats();
     for (const seat of seats) {
       if (seat.getPlayer()?.getUserId() === userId) {
         if (!(game.getGameState().getSeatToAct() === seat.getSeatNumber())) {
-          return Result.error(new NotPlayersTurn());
+          return Result.error(new NotPlayersTurnError());
         }
 
         const player = seat.getPlayer();
         const playerCards = player?.getCards();
         if (!(playerCards && playerCards.length > 0)) {
-          return Result.error(new PlayerAlreadyFolded());
+          return Result.error(new PlayerAlreadyFoldedError());
         }
 
         if (!player) {
-          return Result.error(new PlayerNotFoundAtPokerTableError());
+          return Result.error(new PlayerNotFoundAtTableError());
         }
 
         player.foldCards();

--- a/backend/src/game/PokerTable.test.ts
+++ b/backend/src/game/PokerTable.test.ts
@@ -36,7 +36,7 @@ describe('PokerTable', () => {
       const b1SitsSeat1 = pokerTable.addPlayer(1, userTwo);
 
       expect(b1SitsSeat1.isOk()).toEqual(false);
-      expect(b1SitsSeat1.getError()?.code).toEqual('seat_taken');
+      expect(b1SitsSeat1.getError()?.code).toEqual('SEAT_TAKEN');
       expect(b1SitsSeat1.getError()?.message).toEqual('Seat is taken');
     });
 
@@ -54,7 +54,7 @@ describe('PokerTable', () => {
       const a1SitsSeat2 = pokerTable.addPlayer(2, user);
 
       expect(a1SitsSeat2.isOk()).toEqual(false);
-      expect(a1SitsSeat2.getError()?.code).toEqual('player_already_seated');
+      expect(a1SitsSeat2.getError()?.code).toEqual('PLAYER_ALREADY_SEATED');
       expect(a1SitsSeat2.getError()?.message).toEqual('Player is already seated at the table');
     });
 
@@ -113,8 +113,8 @@ describe('PokerTable', () => {
       const res = pokerTable.removePlayer(1, 1234);
 
       expect(res.isOk()).toEqual(false);
-      expect(res.getError()?.code).toEqual('player_not_found_at_poker_table');
-      expect(res.getError()?.message).toEqual('Player is not seated at the table');
+      expect(res.getError()?.code).toEqual('PLAYER_NOT_FOUND_AT_TABLE');
+      expect(res.getError()?.message).toEqual('The player is not seated at the table');
     });
 
     it('should return the available seat', () => {

--- a/backend/src/game/PokerTable.ts
+++ b/backend/src/game/PokerTable.ts
@@ -3,7 +3,7 @@ import { Result, ResultSuccess } from '@infra/Result';
 import { GameEmitter } from '../game-emitter';
 import { SeatNotFoundError } from '../handlers/poker-tables/errors/SeatNotFoundError';
 import { PlayerAlreadySeatedError } from '../handlers/poker-tables/errors/gen/PlayerAlreadySeatedError';
-import { PlayerNotFoundAtPokerTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError';
+import { PlayerNotFoundAtTableError } from '../handlers/poker-tables/errors/gen/PlayerNotFoundAtTableError';
 import { SeatTakenError } from '../handlers/poker-tables/errors/gen/SeatTakenError';
 import { Dealer } from './Dealer';
 import { Game } from './Game';
@@ -73,7 +73,7 @@ export class PokerTable {
       }
     }
 
-    return Result.error(new PlayerNotFoundAtPokerTableError());
+    return Result.error(new PlayerNotFoundAtTableError());
   }
 
   public addGame(game: Game): void {

--- a/backend/src/handlers/ErrorHandler.ts
+++ b/backend/src/handlers/ErrorHandler.ts
@@ -12,7 +12,7 @@ export class ErrorHandler {
   static handleError(error: IBaseError, clientErrorCodes: { [key: string]: string }, res: Response) {
     if (
       this.isValidErrorCode(error.code, clientErrorCodes) ||
-      error.code === 'invalid_request_payload' ||
+      error.code === 'INVALID_REQUEST_PAYLOAD' ||
       error.code === 'not_authed'
     ) {
       return res.send({

--- a/backend/src/handlers/ValidationErrors.ts
+++ b/backend/src/handlers/ValidationErrors.ts
@@ -2,13 +2,13 @@ import { BaseError } from '@infra/BaseError';
 
 export class InvalidPayloadError extends BaseError {
   constructor(details: any) {
-    super('invalid_payload', 'Invalid payload', details);
+    super('INVALID_PAYLOAD', 'Invalid payload', details);
   }
 }
 
 export class InvalidRequestPayloadError extends BaseError {
   constructor(details: any) {
-    super('invalid_request_payload', 'Invalid request payload', details);
+    super('INVALID_REQUEST_PAYLOAD', 'Invalid request payload', details);
   }
 }
 

--- a/backend/src/handlers/games/bet/GamesBetHandler.ts
+++ b/backend/src/handlers/games/bet/GamesBetHandler.ts
@@ -2,8 +2,8 @@ import { ResultError, ResultSuccess } from '@infra/Result';
 import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { GamesBetOutput, GamesBetPayload } from '@shared/api/gen/games/types/GamesBet';
 
-import { GameDoesNotExist } from '../errors/gen/GameDoesNotExist';
-import { NotPlayersTurn } from '../errors/gen/NotPlayersTurn';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
 import { AbstractGamesBetHandler } from './gen/AbstractGamesBetHandler';

--- a/backend/src/handlers/games/bet/gen/AbstractGamesBetHandler.ts
+++ b/backend/src/handlers/games/bet/gen/AbstractGamesBetHandler.ts
@@ -7,9 +7,9 @@ import { GamesBetPayload, GamesBetOutput } from '@shared/api/gen/games/types/Gam
 
 
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
-import { NotPlayersTurn } from '../errors/gen/NotPlayersTurn';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
-import { GameDoesNotExist } from '../errors/gen/GameDoesNotExist';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
 import { AbstractGamesBetHandler } from './gen/AbstractGamesBetHandler';
 
 export class GamesBetHandler extends AbstractGamesBetHandler {

--- a/backend/src/handlers/games/call/GamesCallHandler.ts
+++ b/backend/src/handlers/games/call/GamesCallHandler.ts
@@ -2,8 +2,8 @@ import { ResultError, ResultSuccess } from '@infra/Result';
 import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { GamesCallOutput, GamesCallPayload } from '@shared/api/gen/games/types/GamesCall';
 
-import { GameDoesNotExist } from '../errors/gen/GameDoesNotExist';
-import { NotPlayersTurn } from '../errors/gen/NotPlayersTurn';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
 import { AbstractGamesCallHandler } from './gen/AbstractGamesCallHandler';

--- a/backend/src/handlers/games/call/gen/AbstractGamesCallHandler.ts
+++ b/backend/src/handlers/games/call/gen/AbstractGamesCallHandler.ts
@@ -7,9 +7,9 @@ import { GamesCallPayload, GamesCallOutput } from '@shared/api/gen/games/types/G
 
 
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
-import { NotPlayersTurn } from '../errors/gen/NotPlayersTurn';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
-import { GameDoesNotExist } from '../errors/gen/GameDoesNotExist';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
 import { AbstractGamesCallHandler } from './gen/AbstractGamesCallHandler';
 
 export class GamesCallHandler extends AbstractGamesCallHandler {

--- a/backend/src/handlers/games/check/GamesCheckHandler.ts
+++ b/backend/src/handlers/games/check/GamesCheckHandler.ts
@@ -1,7 +1,7 @@
 import { ResultError, ResultSuccess } from '@infra/Result';
 import { GamesCheckOutput, GamesCheckPayload } from '@shared/api/gen/games/types/GamesCheck';
 
-import { NotActivePlayerError } from '../errors/gen/NotActivePlayerError';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
 import { AbstractGamesCheckHandler } from './gen/AbstractGamesCheckHandler';

--- a/backend/src/handlers/games/check/gen/AbstractGamesCheckHandler.ts
+++ b/backend/src/handlers/games/check/gen/AbstractGamesCheckHandler.ts
@@ -7,8 +7,9 @@ import { GamesCheckPayload, GamesCheckOutput } from '@shared/api/gen/games/types
 
 
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
-import { NotActivePlayerError } from '../errors/gen/NotActivePlayerError';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
 import { AbstractGamesCheckHandler } from './gen/AbstractGamesCheckHandler';
 
 export class GamesCheckHandler extends AbstractGamesCheckHandler {

--- a/backend/src/handlers/games/errors/gen/GameDoesNotExist.ts
+++ b/backend/src/handlers/games/errors/gen/GameDoesNotExist.ts
@@ -1,7 +1,0 @@
-import { BaseError } from '@infra/BaseError';
-
-export class GameDoesNotExist extends BaseError {
-  constructor() {
-    super('game_does_not_exist', 'Game does not exist');
-  }
-}

--- a/backend/src/handlers/games/errors/gen/GameDoesNotExistError.ts
+++ b/backend/src/handlers/games/errors/gen/GameDoesNotExistError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@infra/BaseError';
+
+export class GameDoesNotExistError extends BaseError {
+  constructor() {
+    super('GAME_DOES_NOT_EXIST', 'The game does not exist');
+  }
+}

--- a/backend/src/handlers/games/errors/gen/GameStateDoesNotExistError.ts
+++ b/backend/src/handlers/games/errors/gen/GameStateDoesNotExistError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class GameStateDoesNotExistError extends BaseError {
   constructor() {
-    super('game_state_does_not_exist', 'The game state does not exist for the specified poker table.');
+    super('GAME_STATE_DOES_NOT_EXIST', 'The game state does not exist');
   }
 }

--- a/backend/src/handlers/games/errors/gen/NotActivePlayerError.ts
+++ b/backend/src/handlers/games/errors/gen/NotActivePlayerError.ts
@@ -1,7 +1,0 @@
-import { BaseError } from '@infra/BaseError';
-
-export class NotActivePlayerError extends BaseError {
-  constructor() {
-    super('player_not_active_player', 'Player is not active player');
-  }
-}

--- a/backend/src/handlers/games/errors/gen/NotPlayersTurn.ts
+++ b/backend/src/handlers/games/errors/gen/NotPlayersTurn.ts
@@ -1,7 +1,0 @@
-import { BaseError } from '@infra/BaseError';
-
-export class NotPlayersTurn extends BaseError {
-  constructor() {
-    super('not_players_turn', 'It is not your turn');
-  }
-}

--- a/backend/src/handlers/games/errors/gen/NotPlayersTurnError.ts
+++ b/backend/src/handlers/games/errors/gen/NotPlayersTurnError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@infra/BaseError';
+
+export class NotPlayersTurnError extends BaseError {
+  constructor() {
+    super('NOT_PLAYERS_TURN', 'It is not the players turn');
+  }
+}

--- a/backend/src/handlers/games/errors/gen/PlayerAlreadyFolded.ts
+++ b/backend/src/handlers/games/errors/gen/PlayerAlreadyFolded.ts
@@ -1,7 +1,0 @@
-import { BaseError } from '@infra/BaseError';
-
-export class PlayerAlreadyFolded extends BaseError {
-  constructor() {
-    super('player_already_folded', 'Player already folded');
-  }
-}

--- a/backend/src/handlers/games/errors/gen/PlayerAlreadyFoldedError.ts
+++ b/backend/src/handlers/games/errors/gen/PlayerAlreadyFoldedError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@infra/BaseError';
+
+export class PlayerAlreadyFoldedError extends BaseError {
+  constructor() {
+    super('PLAYER_ALREADY_FOLDED', 'The Player has already folded');
+  }
+}

--- a/backend/src/handlers/games/errors/gen/PlayerNotFoundAtTableError.ts
+++ b/backend/src/handlers/games/errors/gen/PlayerNotFoundAtTableError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PlayerNotFoundAtTableError extends BaseError {
   constructor() {
-    super('player_not_found_at_poker_table', 'Player is not seated at the table');
+    super('PLAYER_NOT_FOUND_AT_TABLE', 'The player is not seated at the table');
   }
 }

--- a/backend/src/handlers/games/errors/gen/PokerTableDoesNotExistError.ts
+++ b/backend/src/handlers/games/errors/gen/PokerTableDoesNotExistError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PokerTableDoesNotExistError extends BaseError {
   constructor() {
-    super('poker_table_does_not_exist', 'Table does not exist');
+    super('POKER_TABLE_DOES_NOT_EXIST', 'The poker table does not exist');
   }
 }

--- a/backend/src/handlers/games/fold/gen/AbstractGamesFoldHandler.ts
+++ b/backend/src/handlers/games/fold/gen/AbstractGamesFoldHandler.ts
@@ -6,11 +6,11 @@ import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { GamesFoldPayload, GamesFoldOutput } from '@shared/api/gen/games/types/GamesFold';
 
 
+import { PlayerAlreadyFoldedError } from '../errors/gen/PlayerAlreadyFoldedError';
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
-import { NotPlayersTurn } from '../errors/gen/NotPlayersTurn';
+import { NotPlayersTurnError } from '../errors/gen/NotPlayersTurnError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
-import { PlayerAlreadyFolded } from '../errors/gen/PlayerAlreadyFolded';
-import { GameDoesNotExist } from '../errors/gen/GameDoesNotExist';
+import { GameDoesNotExistError } from '../errors/gen/GameDoesNotExistError';
 import { AbstractGamesFoldHandler } from './gen/AbstractGamesFoldHandler';
 
 export class GamesFoldHandler extends AbstractGamesFoldHandler {

--- a/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
+++ b/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
@@ -11,7 +11,7 @@ describe('games.getGameState', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toBe('invalid_request_payload');
+    expect(res.body.error.errorCode).toBe('INVALID_REQUEST_PAYLOAD');
   });
 
   it('should return method_not_implemented', async () => {

--- a/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
+++ b/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
@@ -22,7 +22,7 @@ describe('games.getGameState', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toBe('game_state_does_not_exist');
+    expect(res.body.error.errorCode).toBe('GAME_STATE_DOES_NOT_EXIST');
   });
 
   // TODO: need to add more unit tests for actual game state response

--- a/backend/src/handlers/poker-tables/errors/gen/PlayerAlreadySeatedError.ts
+++ b/backend/src/handlers/poker-tables/errors/gen/PlayerAlreadySeatedError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PlayerAlreadySeatedError extends BaseError {
   constructor() {
-    super('player_already_seated', 'Player is already seated at the table');
+    super('PLAYER_ALREADY_SEATED', 'Player is already seated at the table');
   }
 }

--- a/backend/src/handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError.ts
+++ b/backend/src/handlers/poker-tables/errors/gen/PlayerNotFoundAtPokerTableError.ts
@@ -1,7 +1,0 @@
-import { BaseError } from '@infra/BaseError';
-
-export class PlayerNotFoundAtPokerTableError extends BaseError {
-  constructor() {
-    super('player_not_found_at_poker_table', 'Player is not seated at the table');
-  }
-}

--- a/backend/src/handlers/poker-tables/errors/gen/PlayerNotFoundAtTableError.ts
+++ b/backend/src/handlers/poker-tables/errors/gen/PlayerNotFoundAtTableError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PlayerNotFoundAtTableError extends BaseError {
   constructor() {
-    super('player_not_found_at_poker_table', 'Player is not seated at the table');
+    super('PLAYER_NOT_FOUND_AT_TABLE', 'The player is not seated at the table');
   }
 }

--- a/backend/src/handlers/poker-tables/errors/gen/PokerTableDoesNotExistError.ts
+++ b/backend/src/handlers/poker-tables/errors/gen/PokerTableDoesNotExistError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PokerTableDoesNotExistError extends BaseError {
   constructor() {
-    super('poker_table_does_not_exist', 'Table does not exist');
+    super('POKER_TABLE_DOES_NOT_EXIST', 'The poker table does not exist');
   }
 }

--- a/backend/src/handlers/poker-tables/errors/gen/SeatTakenError.ts
+++ b/backend/src/handlers/poker-tables/errors/gen/SeatTakenError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class SeatTakenError extends BaseError {
   constructor() {
-    super('seat_taken', 'Seat is taken');
+    super('SEAT_TAKEN', 'Seat is taken');
   }
 }

--- a/backend/src/handlers/poker-tables/getSeats/PokerTablesGetSeatsHandler.test.ts
+++ b/backend/src/handlers/poker-tables/getSeats/PokerTablesGetSeatsHandler.test.ts
@@ -26,7 +26,7 @@ describe('poker-tables.getSeats', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toBe('poker_table_does_not_exist');
+    expect(res.body.error.errorCode).toBe('POKER_TABLE_DOES_NOT_EXIST');
   });
 
   it('should return all seats for a table', async () => {

--- a/backend/src/handlers/poker-tables/getSeats/PokerTablesGetSeatsHandler.test.ts
+++ b/backend/src/handlers/poker-tables/getSeats/PokerTablesGetSeatsHandler.test.ts
@@ -15,7 +15,7 @@ describe('poker-tables.getSeats', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toBe('invalid_request_payload');
+    expect(res.body.error.errorCode).toBe('INVALID_REQUEST_PAYLOAD');
   });
 
   it('should return table_does_not_exist', async () => {

--- a/backend/src/handlers/poker-tables/getSeats/gen/AbstractPokerTablesGetSeatsHandler.ts
+++ b/backend/src/handlers/poker-tables/getSeats/gen/AbstractPokerTablesGetSeatsHandler.ts
@@ -2,15 +2,20 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { PokerTablesGetSeatsPayload, PokerTablesGetSeatsOutput } from '@shared/api/gen/poker-tables/types/PokerTablesGetSeats';
 
-import { AbstractPokerTablesGetSeatsHandler } from './gen/AbstractPokerTablesGetSeatsHandler';
 
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
+import { AbstractPokerTablesGetSeatsHandler } from './gen/AbstractPokerTablesGetSeatsHandler';
 
 export class PokerTablesGetSeatsHandler extends AbstractPokerTablesGetSeatsHandler {
   protected async getResult(payload: PokerTablesGetSeatsPayload) {
-    return new ResultSuccess<PokerTablesGetSeatsOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<PokerTablesGetSeatsOutput>();
   }
 }
 */

--- a/backend/src/handlers/poker-tables/join/PokerTablesJoinHandler.test.ts
+++ b/backend/src/handlers/poker-tables/join/PokerTablesJoinHandler.test.ts
@@ -20,7 +20,7 @@ describe('poker-tables.join', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('invalid_request_payload');
+    expect(res.body.error.errorCode).toEqual('INVALID_REQUEST_PAYLOAD');
   });
 
   // TODO: will eventually need to add the table they are sitting at but this is hardcoded

--- a/backend/src/handlers/poker-tables/join/gen/AbstractPokerTablesJoinHandler.ts
+++ b/backend/src/handlers/poker-tables/join/gen/AbstractPokerTablesJoinHandler.ts
@@ -2,18 +2,23 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { PokerTablesJoinPayload, PokerTablesJoinOutput } from '@shared/api/gen/poker-tables/types/PokerTablesJoin';
 
-import { AbstractPokerTablesJoinHandler } from './gen/AbstractPokerTablesJoinHandler';
 
 import { SeatTakenError } from '../errors/gen/SeatTakenError';
 import { PlayerAlreadySeatedError } from '../errors/gen/PlayerAlreadySeatedError';
-import { PlayerNotFoundAtPokerTableError } from '../errors/gen/PlayerNotFoundAtPokerTableError';
+import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
+import { AbstractPokerTablesJoinHandler } from './gen/AbstractPokerTablesJoinHandler';
 
 export class PokerTablesJoinHandler extends AbstractPokerTablesJoinHandler {
   protected async getResult(payload: PokerTablesJoinPayload) {
-    return new ResultSuccess<PokerTablesJoinOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<PokerTablesJoinOutput>();
   }
 }
 */

--- a/backend/src/handlers/poker-tables/leave/PokerTablesLeaveHandler.test.ts
+++ b/backend/src/handlers/poker-tables/leave/PokerTablesLeaveHandler.test.ts
@@ -23,7 +23,7 @@ describe('poker-tables.leave', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('invalid_request_payload');
+    expect(res.body.error.errorCode).toEqual('INVALID_REQUEST_PAYLOAD');
   });
 
   // TODO: will eventually need to add the table they are sitting at but this is hardcoded

--- a/backend/src/handlers/poker-tables/leave/PokerTablesLeaveHandler.test.ts
+++ b/backend/src/handlers/poker-tables/leave/PokerTablesLeaveHandler.test.ts
@@ -57,7 +57,7 @@ describe('poker-tables.leave', () => {
 
     expect(res.statusCode).toEqual(200);
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('player_not_found_at_poker_table');
+    expect(res.body.error.errorCode).toEqual('PLAYER_NOT_FOUND_AT_TABLE');
   });
 
   afterEach(() => {

--- a/backend/src/handlers/poker-tables/leave/gen/AbstractPokerTablesLeaveHandler.ts
+++ b/backend/src/handlers/poker-tables/leave/gen/AbstractPokerTablesLeaveHandler.ts
@@ -2,16 +2,21 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { PokerTablesLeavePayload, PokerTablesLeaveOutput } from '@shared/api/gen/poker-tables/types/PokerTablesLeave';
 
-import { AbstractPokerTablesLeaveHandler } from './gen/AbstractPokerTablesLeaveHandler';
 
 import { PlayerNotFoundAtTableError } from '../errors/gen/PlayerNotFoundAtTableError';
 import { PokerTableDoesNotExistError } from '../errors/gen/PokerTableDoesNotExistError';
+import { AbstractPokerTablesLeaveHandler } from './gen/AbstractPokerTablesLeaveHandler';
 
 export class PokerTablesLeaveHandler extends AbstractPokerTablesLeaveHandler {
   protected async getResult(payload: PokerTablesLeavePayload) {
-    return new ResultSuccess<PokerTablesLeaveOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<PokerTablesLeaveOutput>();
   }
 }
 */

--- a/backend/src/handlers/users/create/UsersCreateHandler.test.ts
+++ b/backend/src/handlers/users/create/UsersCreateHandler.test.ts
@@ -9,7 +9,7 @@ describe('users.create', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('invalid_request_payload');
+    expect(res.body.error.errorCode).toEqual('INVALID_REQUEST_PAYLOAD');
   });
 
   it('should create a user', async () => {

--- a/backend/src/handlers/users/create/gen/AbstractUsersCreateHandler.ts
+++ b/backend/src/handlers/users/create/gen/AbstractUsersCreateHandler.ts
@@ -2,16 +2,21 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { UsersCreatePayload, UsersCreateOutput } from '@shared/api/gen/users/types/UsersCreate';
 
-import { AbstractUsersCreateHandler } from './gen/AbstractUsersCreateHandler';
 
 import { UsernameTakenError } from '../errors/gen/UsernameTakenError';
 import { UsersCreateError } from '../errors/gen/UsersCreateError';
+import { AbstractUsersCreateHandler } from './gen/AbstractUsersCreateHandler';
 
 export class UsersCreateHandler extends AbstractUsersCreateHandler {
   protected async getResult(payload: UsersCreatePayload) {
-    return new ResultSuccess<UsersCreateOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<UsersCreateOutput>();
   }
 }
 */

--- a/backend/src/handlers/users/errors/gen/PasswordInvalidError.ts
+++ b/backend/src/handlers/users/errors/gen/PasswordInvalidError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class PasswordInvalidError extends BaseError {
   constructor() {
-    super('password_invalid', 'Password is invalid');
+    super('PASSWORD_INVALID', 'Password is invalid');
   }
 }

--- a/backend/src/handlers/users/errors/gen/UsernameNotFoundError.ts
+++ b/backend/src/handlers/users/errors/gen/UsernameNotFoundError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class UsernameNotFoundError extends BaseError {
   constructor() {
-    super('username_not_found', 'Username not found');
+    super('USERNAME_NOT_FOUND', 'Username was not found');
   }
 }

--- a/backend/src/handlers/users/errors/gen/UsernameTakenError.ts
+++ b/backend/src/handlers/users/errors/gen/UsernameTakenError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class UsernameTakenError extends BaseError {
   constructor() {
-    super('username_taken', 'Username already taken');
+    super('USERNAME_TAKEN', 'Username is already taken');
   }
 }

--- a/backend/src/handlers/users/errors/gen/UsersCreateError.ts
+++ b/backend/src/handlers/users/errors/gen/UsersCreateError.ts
@@ -2,6 +2,6 @@ import { BaseError } from '@infra/BaseError';
 
 export class UsersCreateError extends BaseError {
   constructor() {
-    super('users_create_error', 'User not created');
+    super('USERS_CREATE_ERROR', 'User was not created');
   }
 }

--- a/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
+++ b/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
@@ -33,7 +33,7 @@ describe('signin', () => {
     });
 
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('invalid_request_payload');
+    expect(res.body.error.errorCode).toEqual('INVALID_REQUEST_PAYLOAD');
   });
 
   it('should respond with a password_invalid error when signing in with a password that is invalid', async () => {

--- a/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
+++ b/backend/src/handlers/users/signin/UsersSigninHandler.test.ts
@@ -48,7 +48,7 @@ describe('signin', () => {
     expect(res.body.ok).toEqual(false);
   });
 
-  it('should respond with a username_not_found when signing in with a username that does not exist', async () => {
+  it('should respond with a USERNAME_NOT_FOUND when signing in with a username that does not exist', async () => {
     mockMySqlSelectSuccessWithNoRows();
 
     const res = await apiTestNoCookie('/api/users.signin', {
@@ -58,7 +58,7 @@ describe('signin', () => {
 
     expect(res.statusCode).toEqual(200);
     expect(res.body.ok).toEqual(false);
-    expect(res.body.error.errorCode).toEqual('username_not_found');
+    expect(res.body.error.errorCode).toEqual('USERNAME_NOT_FOUND');
   });
 
   afterEach(() => {

--- a/backend/src/handlers/users/signin/gen/AbstractUsersSigninHandler.ts
+++ b/backend/src/handlers/users/signin/gen/AbstractUsersSigninHandler.ts
@@ -2,16 +2,21 @@
 !!!! Copy out the below for new or updated API
 
 import { ResultError, ResultSuccess } from '@infra/Result';
+import { MethodNotImplementedError } from '@shared/api/BaseOutput';
 import { UsersSigninPayload, UsersSigninOutput } from '@shared/api/gen/users/types/UsersSignin';
 
-import { AbstractUsersSigninHandler } from './gen/AbstractUsersSigninHandler';
 
 import { UsernameNotFoundError } from '../errors/gen/UsernameNotFoundError';
 import { PasswordInvalidError } from '../errors/gen/PasswordInvalidError';
+import { AbstractUsersSigninHandler } from './gen/AbstractUsersSigninHandler';
 
 export class UsersSigninHandler extends AbstractUsersSigninHandler {
   protected async getResult(payload: UsersSigninPayload) {
-    return new ResultSuccess<UsersSigninOutput>();
+    return new ResultError(new MethodNotImplementedError());
+
+    // 1. After generating the handler, create a PR returning the above
+    // 2. Then implement the handler when the above PR is merged and use the below
+    // return new ResultSuccess<UsersSigninOutput>();
   }
 }
 */

--- a/backend/src/handlers/validatePayload.test.ts
+++ b/backend/src/handlers/validatePayload.test.ts
@@ -35,7 +35,7 @@ describe('validatePayload', () => {
       someNumber: 'one two three',
     };
     const result = validatePayload(joiSchema, payload);
-    expect(result.getError().code).toBe('invalid_payload');
+    expect(result.getError().code).toBe('INVALID_PAYLOAD');
   });
 
   it('should return an error when a required field is missing', () => {
@@ -43,6 +43,6 @@ describe('validatePayload', () => {
       someString: 'Hello World',
     };
     const result = validatePayload(joiSchema, payload);
-    expect(result.getError().code).toBe('invalid_payload');
+    expect(result.getError().code).toBe('INVALID_PAYLOAD');
   });
 });

--- a/backend/src/scripts/generate-handler/tests/apiMetaDataNoOutputTest.json
+++ b/backend/src/scripts/generate-handler/tests/apiMetaDataNoOutputTest.json
@@ -21,7 +21,7 @@
     },
     {
       "errorName": "InvalidRequestPayload",
-      "errorCode": "invalid_request_payload",
+      "errorCode": "INVALID_REQUEST_PAYLOAD",
       "message": "The request payload is invalid.",
       "classFile": "InvalidRequestPayloadError.ts"
     }

--- a/backend/src/shared/api/gen/games/types/GamesBet.ts
+++ b/backend/src/shared/api/gen/games/types/GamesBet.ts
@@ -10,8 +10,8 @@ export interface GamesBetOutput extends BaseOutput {
 }
 
 export enum GamesBetErrorCodes {
-  PlayerNotFoundAtTableError = 'player_not_found_at_poker_table',
-  NotPlayersTurn = 'not_players_turn',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
-  GameDoesNotExist = 'game_does_not_exist',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  NotPlayersTurnError = 'NOT_PLAYERS_TURN',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
+  GameDoesNotExistError = 'GAME_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/games/types/GamesCall.ts
+++ b/backend/src/shared/api/gen/games/types/GamesCall.ts
@@ -9,8 +9,8 @@ export interface GamesCallOutput extends BaseOutput {
 }
 
 export enum GamesCallErrorCodes {
-  PlayerNotFoundAtTableError = 'player_not_found_at_poker_table',
-  NotPlayersTurn = 'not_players_turn',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
-  GameDoesNotExist = 'game_does_not_exist',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  NotPlayersTurnError = 'NOT_PLAYERS_TURN',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
+  GameDoesNotExistError = 'GAME_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/games/types/GamesCheck.ts
+++ b/backend/src/shared/api/gen/games/types/GamesCheck.ts
@@ -9,7 +9,8 @@ export interface GamesCheckOutput extends BaseOutput {
 }
 
 export enum GamesCheckErrorCodes {
-  PlayerNotFoundAtTableError = 'player_not_found_at_poker_table',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
-  NotActivePlayerError = 'player_not_active_player',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  NotPlayersTurnError = 'NOT_PLAYERS_TURN',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
+  GameDoesNotExistError = 'GAME_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/games/types/GamesFold.ts
+++ b/backend/src/shared/api/gen/games/types/GamesFold.ts
@@ -9,9 +9,9 @@ export interface GamesFoldOutput extends BaseOutput {
 }
 
 export enum GamesFoldErrorCodes {
-  PlayerNotFoundAtTableError = 'player_not_found_at_poker_table',
-  NotPlayersTurn = 'not_players_turn',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
-  PlayerAlreadyFolded = 'player_already_folded',
-  GameDoesNotExist = 'game_does_not_exist',
+  PlayerAlreadyFoldedError = 'PLAYER_ALREADY_FOLDED',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  NotPlayersTurnError = 'NOT_PLAYERS_TURN',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
+  GameDoesNotExistError = 'GAME_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/games/types/GamesGetGameState.ts
+++ b/backend/src/shared/api/gen/games/types/GamesGetGameState.ts
@@ -28,6 +28,6 @@ export interface GamesGetGameStateOutput extends BaseOutput {
 }
 
 export enum GamesGetGameStateErrorCodes {
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
-  GameStateDoesNotExistError = 'game_state_does_not_exist',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
+  GameStateDoesNotExistError = 'GAME_STATE_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/poker-tables/schemas/PokerTablesGetSeatsSchemas.ts
+++ b/backend/src/shared/api/gen/poker-tables/schemas/PokerTablesGetSeatsSchemas.ts
@@ -9,11 +9,6 @@ export const PokerTablesGetSeatsPayloadSchema = Joi.object<PokerTablesGetSeatsPa
 export const PokerTablesGetSeatsOutputSchema = Joi.object<PokerTablesGetSeatsOutput>({
   ok: Joi.boolean().required(),
   seats: Joi.array()
-    .items(
-      Joi.object({
-        seatNumber: Joi.number().required(),
-        username: Joi.string().required().allow(''),
-      }),
-    )
+    .items(Joi.object({ seatNumber: Joi.number().required(), username: Joi.string().required().allow('') }))
     .required(),
 }).unknown(false);

--- a/backend/src/shared/api/gen/poker-tables/types/PokerTablesGetSeats.ts
+++ b/backend/src/shared/api/gen/poker-tables/types/PokerTablesGetSeats.ts
@@ -13,5 +13,5 @@ export interface PokerTablesGetSeatsOutput extends BaseOutput {
 }
 
 export enum PokerTablesGetSeatsErrorCodes {
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/poker-tables/types/PokerTablesJoin.ts
+++ b/backend/src/shared/api/gen/poker-tables/types/PokerTablesJoin.ts
@@ -9,8 +9,8 @@ export interface PokerTablesJoinOutput extends BaseOutput {
 }
 
 export enum PokerTablesJoinErrorCodes {
-  SeatTakenError = 'seat_taken',
-  PlayerAlreadySeatedError = 'player_already_seated',
-  PlayerNotFoundAtPokerTableError = 'player_not_found_at_poker_table',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
+  SeatTakenError = 'SEAT_TAKEN',
+  PlayerAlreadySeatedError = 'PLAYER_ALREADY_SEATED',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/poker-tables/types/PokerTablesLeave.ts
+++ b/backend/src/shared/api/gen/poker-tables/types/PokerTablesLeave.ts
@@ -9,6 +9,6 @@ export interface PokerTablesLeaveOutput extends BaseOutput {
 }
 
 export enum PokerTablesLeaveErrorCodes {
-  PlayerNotFoundAtTableError = 'player_not_found_at_poker_table',
-  PokerTableDoesNotExistError = 'poker_table_does_not_exist',
+  PlayerNotFoundAtTableError = 'PLAYER_NOT_FOUND_AT_TABLE',
+  PokerTableDoesNotExistError = 'POKER_TABLE_DOES_NOT_EXIST',
 }

--- a/backend/src/shared/api/gen/users/types/UsersCreate.ts
+++ b/backend/src/shared/api/gen/users/types/UsersCreate.ts
@@ -10,6 +10,6 @@ export interface UsersCreateOutput extends BaseOutput {
 }
 
 export enum UsersCreateErrorCodes {
-  UsernameTakenError = 'username_taken',
-  UsersCreateError = 'users_create_error',
+  UsernameTakenError = 'USERNAME_TAKEN',
+  UsersCreateError = 'USERS_CREATE_ERROR',
 }

--- a/backend/src/shared/api/gen/users/types/UsersSignin.ts
+++ b/backend/src/shared/api/gen/users/types/UsersSignin.ts
@@ -10,6 +10,6 @@ export interface UsersSigninOutput extends BaseOutput {
 }
 
 export enum UsersSigninErrorCodes {
-  UsernameNotFoundError = 'username_not_found',
-  PasswordInvalidError = 'password_invalid',
+  UsernameNotFoundError = 'USERNAME_NOT_FOUND',
+  PasswordInvalidError = 'PASSWORD_INVALID',
 }

--- a/backend/src/shared/api/metadata/games_bet.json
+++ b/backend/src/shared/api/metadata/games_bet.json
@@ -1,53 +1,52 @@
 {
-    "handlerName": "GamesBet",
-    "domainName": "games",
-    "apiVerb": "bet",
-    "httpMethod": "post",
-    "authRequired": true,
-    "payload": {
-      "properties": [
-        {
-          "name": "pokerTableName",
-          "type": "string",
-          "required": true
-        },
-        {
-          "name": "amount",
-          "type": "number",
-          "required": true
-        }
-      ]
-    },
-    "output": {
-      "properties": [
-        {
-          "name": "ok",
-          "type": "boolean",
-          "required": true
-        }
-      ]
-    },
-    "errors": [
+  "handlerName": "GamesBet",
+  "domainName": "games",
+  "apiVerb": "bet",
+  "httpMethod": "post",
+  "authRequired": true,
+  "payload": {
+    "properties": [
       {
-        "errorName": "PlayerNotFoundAtTableError",
-        "errorCode": "player_not_found_at_poker_table",
-        "message": "Player is not seated at the table"
+        "name": "pokerTableName",
+        "type": "string",
+        "required": true
       },
       {
-        "errorName": "NotPlayersTurn",
-        "errorCode": "not_players_turn",
-        "message": "It is not your turn"
-      },
-      {
-        "errorName": "PokerTableDoesNotExistError",
-        "errorCode": "poker_table_does_not_exist",
-        "message": "Table does not exist"
-      },
-      {
-        "errorName": "GameDoesNotExist",
-        "errorCode": "game_does_not_exist",
-        "message": "Game does not exist"
+        "name": "amount",
+        "type": "number",
+        "required": true
       }
     ]
-  }
-  
+  },
+  "output": {
+    "properties": [
+      {
+        "name": "ok",
+        "type": "boolean",
+        "required": true
+      }
+    ]
+  },
+  "errors": [
+    {
+      "errorName": "PlayerNotFoundAtTableError",
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
+    },
+    {
+      "errorName": "NotPlayersTurnError",
+      "errorCode": "NOT_PLAYERS_TURN",
+      "message": "It is not the players turn"
+    },
+    {
+      "errorName": "PokerTableDoesNotExistError",
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
+    },
+    {
+      "errorName": "GameDoesNotExistError",
+      "errorCode": "GAME_DOES_NOT_EXIST",
+      "message": "The game does not exist"
+    }
+  ]
+}

--- a/backend/src/shared/api/metadata/games_call.json
+++ b/backend/src/shared/api/metadata/games_call.json
@@ -1,48 +1,47 @@
 {
-    "handlerName": "GamesCall",
-    "domainName": "games",
-    "apiVerb": "call",
-    "httpMethod": "post",
-    "authRequired": true,
-    "payload": {
-      "properties": [
-        {
-          "name": "pokerTableName",
-          "type": "string",
-          "required": true
-        }
-      ]
-    },
-    "output": {
-      "properties": [
-        {
-          "name": "ok",
-          "type": "boolean",
-          "required": true
-        }
-      ]
-    },
-    "errors": [
+  "handlerName": "GamesCall",
+  "domainName": "games",
+  "apiVerb": "call",
+  "httpMethod": "post",
+  "authRequired": true,
+  "payload": {
+    "properties": [
       {
-        "errorName": "PlayerNotFoundAtTableError",
-        "errorCode": "player_not_found_at_poker_table",
-        "message": "Player is not seated at the table"
-      },
-      {
-        "errorName": "NotPlayersTurn",
-        "errorCode": "not_players_turn",
-        "message": "It is not your turn"
-      },
-      {
-        "errorName": "PokerTableDoesNotExistError",
-        "errorCode": "poker_table_does_not_exist",
-        "message": "Table does not exist"
-      },
-      {
-        "errorName": "GameDoesNotExist",
-        "errorCode": "game_does_not_exist",
-        "message": "Game does not exist"
+        "name": "pokerTableName",
+        "type": "string",
+        "required": true
       }
     ]
-  }
-  
+  },
+  "output": {
+    "properties": [
+      {
+        "name": "ok",
+        "type": "boolean",
+        "required": true
+      }
+    ]
+  },
+  "errors": [
+    {
+      "errorName": "PlayerNotFoundAtTableError",
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
+    },
+    {
+      "errorName": "NotPlayersTurnError",
+      "errorCode": "NOT_PLAYERS_TURN",
+      "message": "It is not the players turn"
+    },
+    {
+      "errorName": "PokerTableDoesNotExistError",
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
+    },
+    {
+      "errorName": "GameDoesNotExistError",
+      "errorCode": "GAME_DOES_NOT_EXIST",
+      "message": "The game does not exist"
+    }
+  ]
+}

--- a/backend/src/shared/api/metadata/games_check.json
+++ b/backend/src/shared/api/metadata/games_check.json
@@ -25,18 +25,23 @@
   "errors": [
     {
       "errorName": "PlayerNotFoundAtTableError",
-      "errorCode": "player_not_found_at_poker_table",
-      "message": "Player is not seated at the table"
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
+    },
+    {
+      "errorName": "NotPlayersTurnError",
+      "errorCode": "NOT_PLAYERS_TURN",
+      "message": "It is not the players turn"
     },
     {
       "errorName": "PokerTableDoesNotExistError",
-      "errorCode": "poker_table_does_not_exist",
-      "message": "Table does not exist"
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
     },
     {
-      "errorName": "NotActivePlayerError",
-      "errorCode": "player_not_active_player",
-      "message": "Player is not active player"
+      "errorName": "GameDoesNotExistError",
+      "errorCode": "GAME_DOES_NOT_EXIST",
+      "message": "The game does not exist"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/games_fold.json
+++ b/backend/src/shared/api/metadata/games_fold.json
@@ -1,53 +1,52 @@
 {
-    "handlerName": "GamesFold",
-    "domainName": "games",
-    "apiVerb": "fold",
-    "httpMethod": "post",
-    "authRequired": true,
-    "payload": {
-      "properties": [
-        {
-          "name": "pokerTableName",
-          "type": "string",
-          "required": true
-        }
-      ]
-    },
-    "output": {
-      "properties": [
-        {
-          "name": "ok",
-          "type": "boolean",
-          "required": true
-        }
-      ]
-    },
-    "errors": [
+  "handlerName": "GamesFold",
+  "domainName": "games",
+  "apiVerb": "fold",
+  "httpMethod": "post",
+  "authRequired": true,
+  "payload": {
+    "properties": [
       {
-        "errorName": "PlayerNotFoundAtTableError",
-        "errorCode": "player_not_found_at_poker_table",
-        "message": "Player is not seated at the table"
-      },
-      {
-        "errorName": "NotPlayersTurn",
-        "errorCode": "not_players_turn",
-        "message": "It is not your turn"
-      },
-      {
-        "errorName": "PokerTableDoesNotExistError",
-        "errorCode": "poker_table_does_not_exist",
-        "message": "Table does not exist"
-      },
-      {
-        "errorName": "PlayerAlreadyFolded",
-        "errorCode": "player_already_folded",
-        "message": "Player already folded"
-      },
-      {
-        "errorName": "GameDoesNotExist",
-        "errorCode": "game_does_not_exist",
-        "message": "Game does not exist"
+        "name": "pokerTableName",
+        "type": "string",
+        "required": true
       }
     ]
-  }
-  
+  },
+  "output": {
+    "properties": [
+      {
+        "name": "ok",
+        "type": "boolean",
+        "required": true
+      }
+    ]
+  },
+  "errors": [
+    {
+      "errorName": "PlayerAlreadyFoldedError",
+      "errorCode": "PLAYER_ALREADY_FOLDED",
+      "message": "The Player has already folded"
+    },
+    {
+      "errorName": "PlayerNotFoundAtTableError",
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
+    },
+    {
+      "errorName": "NotPlayersTurnError",
+      "errorCode": "NOT_PLAYERS_TURN",
+      "message": "It is not the players turn"
+    },
+    {
+      "errorName": "PokerTableDoesNotExistError",
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
+    },
+    {
+      "errorName": "GameDoesNotExistError",
+      "errorCode": "GAME_DOES_NOT_EXIST",
+      "message": "The game does not exist"
+    }
+  ]
+}

--- a/backend/src/shared/api/metadata/games_getGameState.json
+++ b/backend/src/shared/api/metadata/games_getGameState.json
@@ -119,13 +119,13 @@
   "errors": [
     {
       "errorName": "PokerTableDoesNotExistError",
-      "errorCode": "poker_table_does_not_exist",
-      "message": "The specified poker table does not exist."
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
     },
     {
       "errorName": "GameStateDoesNotExistError",
-      "errorCode": "game_state_does_not_exist",
-      "message": "The game state does not exist for the specified poker table."
+      "errorCode": "GAME_STATE_DOES_NOT_EXIST",
+      "message": "The game state does not exist"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/poker_tables_getSeats.json
+++ b/backend/src/shared/api/metadata/poker_tables_getSeats.json
@@ -46,8 +46,8 @@
   "errors": [
     {
       "errorName": "PokerTableDoesNotExistError",
-      "errorCode": "poker_table_does_not_exist",
-      "message": "The specified poker table does not exist."
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/poker_tables_join.json
+++ b/backend/src/shared/api/metadata/poker_tables_join.json
@@ -25,23 +25,23 @@
   "errors": [
     {
       "errorName": "SeatTakenError",
-      "errorCode": "seat_taken",
+      "errorCode": "SEAT_TAKEN",
       "message": "Seat is taken"
     },
     {
       "errorName": "PlayerAlreadySeatedError",
-      "errorCode": "player_already_seated",
+      "errorCode": "PLAYER_ALREADY_SEATED",
       "message": "Player is already seated at the table"
     },
     {
-      "errorName": "PlayerNotFoundAtPokerTableError",
-      "errorCode": "player_not_found_at_poker_table",
-      "message": "Player is not seated at the table"
+      "errorName": "PlayerNotFoundAtTableError",
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
     },
     {
       "errorName": "PokerTableDoesNotExistError",
-      "errorCode": "poker_table_does_not_exist",
-      "message": "Poker table does not exist"
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/poker_tables_leave.json
+++ b/backend/src/shared/api/metadata/poker_tables_leave.json
@@ -25,13 +25,13 @@
   "errors": [
     {
       "errorName": "PlayerNotFoundAtTableError",
-      "errorCode": "player_not_found_at_poker_table",
-      "message": "Player is not seated at the table"
+      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
+      "message": "The player is not seated at the table"
     },
     {
       "errorName": "PokerTableDoesNotExistError",
-      "errorCode": "poker_table_does_not_exist",
-      "message": "Table does not exist"
+      "errorCode": "POKER_TABLE_DOES_NOT_EXIST",
+      "message": "The poker table does not exist"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/users_create.json
+++ b/backend/src/shared/api/metadata/users_create.json
@@ -30,13 +30,13 @@
   "errors": [
     {
       "errorName": "UsernameTakenError",
-      "errorCode": "username_taken",
-      "message": "Username already taken"
+      "errorCode": "USERNAME_TAKEN",
+      "message": "Username is already taken"
     },
     {
       "errorName": "UsersCreateError",
-      "errorCode": "users_create_error",
-      "message": "User not created"
+      "errorCode": "USERS_CREATE_ERROR",
+      "message": "User was not created"
     }
   ]
 }

--- a/backend/src/shared/api/metadata/users_signin.json
+++ b/backend/src/shared/api/metadata/users_signin.json
@@ -30,12 +30,12 @@
   "errors": [
     {
       "errorName": "UsernameNotFoundError",
-      "errorCode": "username_not_found",
-      "message": "Username not found"
+      "errorCode": "USERNAME_NOT_FOUND",
+      "message": "Username was not found"
     },
     {
       "errorName": "PasswordInvalidError",
-      "errorCode": "password_invalid",
+      "errorCode": "PASSWORD_INVALID",
       "message": "Password is invalid"
     }
   ]

--- a/backend/test-requests/signin.http
+++ b/backend/test-requests/signin.http
@@ -12,7 +12,7 @@ content-type: application/json
     "password": "testpassword"
 }
 
-### should error with invalid_request_payload and error_details:
+### should error with INVALID_REQUEST_PAYLOAD and error_details:
 
 POST http://localhost:3000/api/users.signin
 content-type: application/json


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

Make errors consistent

1. `errorName` should end with `Errror`
2. `errorCode` should be capitalised and should be the error name but not include `Errror`
3. `message` should be directed at the developer giving the error in english (the FE error message for the player would be explicitly created on the FE off the back of the errorCode)

```
   {
      "errorName": "PlayerNotFoundAtTableError",
      "errorCode": "PLAYER_NOT_FOUND_AT_TABLE",
      "message": "The player is not seated at the table"
    },
```

### How to test

All tests should pass