### PR TITLE
feat: show chips on bet

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.css$': '<rootDir>/mocks/styleMock.js',
   },
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
   transform: {

--- a/frontend/mocks/styleMock.js
+++ b/frontend/mocks/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -11,7 +11,7 @@
   color: white;
   border: 2px solid black; /* Add black border */
   margin-top: -50px; /* Space between chips in a pile */
-  margin-bottom: 4px; /* Space between chips in a pile */
+  margin-bottom: 4px; /*  Space between chips in a pile */
 }
 
 .chip-value {
@@ -45,10 +45,19 @@
   background-color: rgb(0, 217, 255);
 }
 
+.chip-5000 {
+  background-color: rgb(140, 0, 255);
+}
+
+.chip-10000 {
+  background-color: rgb(255, 0, 144);
+}
+
 /* Add more styles for other denominations if needed */
 
 /* App.css */
 .chip-display {
+  width: 400px;
   position: absolute;
   bottom: 100px;
   display: flex;

--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -59,33 +59,28 @@
 .chip-index-3 {
   top: -15px;
 }
-
 .chip-index-4 {
   top: -20px;
 }
-
 .chip-index-5 {
   top: -25px;
 }
-
 .chip-index-6 {
   top: -30px;
 }
-
 .chip-index-7 {
   top: -35px;
 }
-
 .chip-index-8 {
   top: -40px;
 }
-
 .chip-index-9 {
   top: -45px;
 }
 /* Add more rules as needed */
 
 /* App.css */
+/* TODO: can I change this to a flex box */
 .chip-display {
   position: relative; /* Change this to relative */
   width: 60px; /* Adjust width to match chip size */

--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -4,13 +4,14 @@
   width: 50px;
   height: 50px;
   border-radius: 50%;
-  margin: 5px;
-  position: absolute; /* Change this to absolute */
+  position: relative; /* Change to relative for Flexbox */
   text-align: center;
   line-height: 50px;
   font-weight: bold;
   color: white;
   border: 2px solid black; /* Add black border */
+  margin-top: -50px; /* Space between chips in a pile */
+  margin-bottom: 4px; /* Space between chips in a pile */
 }
 
 .chip-value {
@@ -21,69 +22,44 @@
 }
 
 .chip-1 {
-  left: 200px;
   background-color: red;
 }
 
 .chip-5 {
-  left: 150px;
   background-color: blue;
 }
 
 .chip-10 {
-  left: 100px;
   background-color: green;
-}
-
-.chip-50 {
-  left: 50px;
-  background-color: grey;
 }
 
 .chip-100 {
   background-color: gold;
 }
 
+.chip-500 {
+  background-color: rgb(251, 0, 255);
+}
+
+.chip-1000 {
+  background-color: rgb(0, 217, 255);
+}
+
 /* Add more styles for other denominations if needed */
 
-/* Add stacking offset based on index */
-.chip-index-0 {
-  top: 0;
-}
-.chip-index-1 {
-  top: -5px;
-}
-.chip-index-2 {
-  top: -10px;
-}
-.chip-index-3 {
-  top: -15px;
-}
-.chip-index-4 {
-  top: -20px;
-}
-.chip-index-5 {
-  top: -25px;
-}
-.chip-index-6 {
-  top: -30px;
-}
-.chip-index-7 {
-  top: -35px;
-}
-.chip-index-8 {
-  top: -40px;
-}
-.chip-index-9 {
-  top: -45px;
-}
-/* Add more rules as needed */
-
 /* App.css */
-/* TODO: can I change this to a flex box */
 .chip-display {
-  position: relative; /* Change this to relative */
-  width: 60px; /* Adjust width to match chip size */
-  height: auto;
-  margin: 20px;
+  position: absolute;
+  bottom: 100px;
+  display: flex;
+  gap: 1px; /* Space between piles */
+  flex-wrap: wrap;
+  align-items: flex-end; /* Align chips at the bottom */
+}
+
+.chip-pile {
+  position: relative;
+  width: 50px;
+  display: flex;
+  flex-direction: column; /* Stack chips from bottom to top */
 }

--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -1,0 +1,94 @@
+/* Chip.css */
+.chip {
+  display: inline-block;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin: 5px;
+  position: absolute; /* Change this to absolute */
+  text-align: center;
+  line-height: 50px;
+  font-weight: bold;
+  color: white;
+  border: 2px solid black; /* Add black border */
+}
+
+.chip-value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.chip-1 {
+  left: 200px;
+  background-color: red;
+}
+
+.chip-5 {
+  left: 150px;
+  background-color: blue;
+}
+
+.chip-10 {
+  left: 100px;
+  background-color: green;
+}
+
+.chip-50 {
+  left: 50px;
+  background-color: grey;
+}
+
+.chip-100 {
+  background-color: gold;
+}
+
+/* Add more styles for other denominations if needed */
+
+/* Add stacking offset based on index */
+.chip-index-0 {
+  top: 0;
+}
+.chip-index-1 {
+  top: -5px;
+}
+.chip-index-2 {
+  top: -10px;
+}
+.chip-index-3 {
+  top: -15px;
+}
+
+.chip-index-4 {
+  top: -20px;
+}
+
+.chip-index-5 {
+  top: -25px;
+}
+
+.chip-index-6 {
+  top: -30px;
+}
+
+.chip-index-7 {
+  top: -35px;
+}
+
+.chip-index-8 {
+  top: -40px;
+}
+
+.chip-index-9 {
+  top: -45px;
+}
+/* Add more rules as needed */
+
+/* App.css */
+.chip-display {
+  position: relative; /* Change this to relative */
+  width: 60px; /* Adjust width to match chip size */
+  height: auto;
+  margin: 20px;
+}

--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -1,4 +1,3 @@
-/* Chip.css */
 .chip {
   display: inline-block;
   width: 50px;
@@ -59,11 +58,21 @@
 .chip-display {
   width: 400px;
   position: absolute;
-  bottom: 100px;
+  bottom: 125px;
   display: flex;
   gap: 1px; /* Space between piles */
   flex-wrap: wrap;
   align-items: flex-end; /* Align chips at the bottom */
+}
+
+.chip-total-label {
+  text-align: right;
+  font-size: 24px;
+  background-color: white;
+  border: 4px solid;
+  border-color: black;
+  border-radius: 10px;
+  padding: 5px;
 }
 
 .chip-pile {

--- a/frontend/src/components/Chips/Chip.tsx
+++ b/frontend/src/components/Chips/Chip.tsx
@@ -1,11 +1,18 @@
+import React from 'react';
+
 import './Chip.css';
 
-const Chip = ({ value, index }) => {
+interface ChipProps {
+  value: number;
+  style?: React.CSSProperties;
+}
+
+function Chip({ value, style }: ChipProps) {
   return (
-    <div className={`chip chip-${value} chip-index-${index}`}>
+    <div className={`chip chip-${value}`} style={style}>
       <span className="chip-value">{value}</span>
     </div>
   );
-};
+}
 
 export default Chip;

--- a/frontend/src/components/Chips/Chip.tsx
+++ b/frontend/src/components/Chips/Chip.tsx
@@ -1,0 +1,11 @@
+import './Chip.css';
+
+const Chip = ({ value, index }) => {
+  return (
+    <div className={`chip chip-${value} chip-index-${index}`}>
+      <span className="chip-value">{value}</span>
+    </div>
+  );
+};
+
+export default Chip;

--- a/frontend/src/components/Chips/ChipDisplay.tsx
+++ b/frontend/src/components/Chips/ChipDisplay.tsx
@@ -1,0 +1,22 @@
+// ChipDisplay.js
+import React from 'react';
+
+import Chip from './Chip';
+
+const ChipDisplay = ({ totalValue }) => {
+  const denominations = [100, 50, 10, 5, 1]; // Add more denominations as needed
+  let remainingValue = totalValue;
+  const chips = [];
+
+  denominations.forEach((denom) => {
+    const count = Math.floor(remainingValue / denom);
+    remainingValue %= denom;
+    for (let i = 0; i < count; i++) {
+      chips.push(<Chip key={`${denom}-${i}`} value={denom} index={i} />);
+    }
+  });
+
+  return <div className="chip-display">{chips}</div>;
+};
+
+export default ChipDisplay;

--- a/frontend/src/components/Chips/ChipDisplay.tsx
+++ b/frontend/src/components/Chips/ChipDisplay.tsx
@@ -1,22 +1,41 @@
-// ChipDisplay.js
+// ChipDisplay.tsx
 import React from 'react';
 
 import Chip from './Chip';
 
-const ChipDisplay = ({ totalValue }) => {
-  const denominations = [100, 50, 10, 5, 1]; // Add more denominations as needed
+interface ChipDisplayProps {
+  totalValue: number;
+}
+
+function ChipDisplay({ totalValue }: ChipDisplayProps) {
+  const denominations = [1000, 500, 100, 10, 5, 1]; // Add more denominations as needed
   let remainingValue = totalValue;
-  const chips = [];
+  const piles = [];
+  const maxChipsPerPile = 10; // Maximum number of chips per pile
 
   denominations.forEach((denom) => {
     const count = Math.floor(remainingValue / denom);
     remainingValue %= denom;
-    for (let i = 0; i < count; i++) {
-      chips.push(<Chip key={`${denom}-${i}`} value={denom} index={i} />);
+    const pileCount = Math.ceil(count / maxChipsPerPile);
+
+    for (let pileIndex = 0; pileIndex < pileCount; pileIndex++) {
+      const chips = [];
+      for (let i = 0; i < maxChipsPerPile; i++) {
+        const chipIndex = pileIndex * maxChipsPerPile + i;
+        if (chipIndex >= count) break;
+        const top = i * -10; // Adjust stacking offset
+
+        chips.push(<Chip key={`${denom}-${chipIndex}`} value={denom} style={{ top: `${top}px` }} />);
+      }
+      piles.push(
+        <div key={`pile-${denom}-${pileIndex}`} className="chip-pile">
+          {chips}
+        </div>,
+      );
     }
   });
 
-  return <div className="chip-display">{chips}</div>;
-};
+  return <div className="chip-display">{piles}</div>;
+}
 
 export default ChipDisplay;

--- a/frontend/src/components/Chips/ChipDisplay.tsx
+++ b/frontend/src/components/Chips/ChipDisplay.tsx
@@ -8,7 +8,8 @@ interface ChipDisplayProps {
 }
 
 function ChipDisplay({ totalValue }: ChipDisplayProps) {
-  const denominations = [1000, 500, 100, 10, 5, 1]; // Add more denominations as needed
+  const denominations = [10000, 5000, 1000, 500, 100, 10, 5, 1]; // Add more denominations as needed
+
   let remainingValue = totalValue;
   const piles = [];
   const maxChipsPerPile = 10; // Maximum number of chips per pile
@@ -23,10 +24,11 @@ function ChipDisplay({ totalValue }: ChipDisplayProps) {
       for (let i = 0; i < maxChipsPerPile; i++) {
         const chipIndex = pileIndex * maxChipsPerPile + i;
         if (chipIndex >= count) break;
-        const top = i * -10; // Adjust stacking offset
+        const top = i * -8; // Adjust stacking offset
 
         chips.push(<Chip key={`${denom}-${chipIndex}`} value={denom} style={{ top: `${top}px` }} />);
       }
+
       piles.push(
         <div key={`pile-${denom}-${pileIndex}`} className="chip-pile">
           {chips}

--- a/frontend/src/components/Chips/ChipDisplay.tsx
+++ b/frontend/src/components/Chips/ChipDisplay.tsx
@@ -1,6 +1,3 @@
-// ChipDisplay.tsx
-import React from 'react';
-
 import Chip from './Chip';
 
 interface ChipDisplayProps {
@@ -11,7 +8,7 @@ function ChipDisplay({ totalValue }: ChipDisplayProps) {
   const denominations = [10000, 5000, 1000, 500, 100, 10, 5, 1]; // Add more denominations as needed
 
   let remainingValue = totalValue;
-  const piles = [];
+  const piles: React.ReactElement[] = [];
   const maxChipsPerPile = 10; // Maximum number of chips per pile
 
   denominations.forEach((denom) => {
@@ -37,7 +34,12 @@ function ChipDisplay({ totalValue }: ChipDisplayProps) {
     }
   });
 
-  return <div className="chip-display">{piles}</div>;
+  return (
+    <div className="chip-display">
+      {piles}
+      <div className="chip-total-label">{totalValue}</div>
+    </div>
+  );
 }
 
 export default ChipDisplay;

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -8,7 +8,7 @@ type ActionsProps = {
   bigBlind?: number;
 };
 
-const MAX_AMOUNT = 1000;
+const MAX_AMOUNT = 100000;
 
 function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
   const [betAmount, setBetAmount] = useState(bigBlind);

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import apiCall from '../../../fetch/apiCall';
+import ChipDisplay from '../../Chips/ChipDisplay';
 
 type ActionsProps = {
   isMyTurn: boolean;
@@ -126,6 +127,7 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
           <button className="action-buttons" id="raise-action-button" aria-label="Bet" onClick={bet}>
             {allIn ? 'All In' : 'Bet'}
           </button>
+          <ChipDisplay totalValue={betAmount} />;
         </div>
       )}
     </div>

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -12,6 +12,7 @@ const MAX_AMOUNT = 100000;
 
 function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
   const [betAmount, setBetAmount] = useState(bigBlind);
+  const [showChipDisplay, setShowChipDisplay] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [allIn, setAllIn] = useState(false);
 
@@ -54,6 +55,8 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
       return;
     }
     setErrorMessage('');
+
+    setShowChipDisplay(true);
 
     const payload = { pokerTableName: 'table_1', amount: betAmount };
 
@@ -127,7 +130,7 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
           <button className="action-buttons" id="raise-action-button" aria-label="Bet" onClick={bet}>
             {allIn ? 'All In' : 'Bet'}
           </button>
-          <ChipDisplay totalValue={betAmount} />;
+          {showChipDisplay && <ChipDisplay totalValue={betAmount} />}
         </div>
       )}
     </div>


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

This PR adds the poker chip visuals when the player clicks bet

### How to test

<!--- Steps on how to test this change  --->

1. Seat two players
2. For the active player, choose an amount and click Bet

Expected: to see the chips and the total amount beside or below it

Note: the below gif shows the chips updating on sliding, but this is a bit over the top so they will only show once the player clicks bet. 

Eventually they will only show after the bet has been validated and send back along the socket. It will also show beside the players stack (and the table will be bigger)
![chip display](https://github.com/richardaspinall/poker-react-node/assets/15721687/e8399ce5-67fa-40f9-b0ee-135cdd5edaa1)


### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->

[CU-86cvvwpb4 ](https://app.clickup.com/t/86cvvwpb4)
