### PR TITLE
feat: show chip counts

### DIFF
--- a/frontend/src/components/Chips/Chip.css
+++ b/frontend/src/components/Chips/Chip.css
@@ -32,6 +32,10 @@
   background-color: green;
 }
 
+.chip-50 {
+  background-color: rgb(5, 160, 244);
+}
+
 .chip-100 {
   background-color: gold;
 }
@@ -56,13 +60,16 @@
 
 /* App.css */
 .chip-display {
-  width: 400px;
+  width: 450px;
   position: absolute;
-  bottom: 125px;
+  bottom: -125px;
+  left: 20%;
+  /* transform: translateX(-50%); */
   display: flex;
   gap: 1px; /* Space between piles */
   flex-wrap: wrap;
   align-items: flex-end; /* Align chips at the bottom */
+  z-index: 1;
 }
 
 .chip-total-label {

--- a/frontend/src/components/Chips/ChipDisplay.tsx
+++ b/frontend/src/components/Chips/ChipDisplay.tsx
@@ -5,7 +5,7 @@ interface ChipDisplayProps {
 }
 
 function ChipDisplay({ totalValue }: ChipDisplayProps) {
-  const denominations = [10000, 5000, 1000, 500, 100, 10, 5, 1]; // Add more denominations as needed
+  const denominations = [10000, 5000, 1000, 500, 100, 50, 10, 5, 1]; // Add more denominations as needed
 
   let remainingValue = totalValue;
   const piles: React.ReactElement[] = [];

--- a/frontend/src/components/PokerTable/Actions/Actions.tsx
+++ b/frontend/src/components/PokerTable/Actions/Actions.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 
 import apiCall from '../../../fetch/apiCall';
-import ChipDisplay from '../../Chips/ChipDisplay';
 
 type ActionsProps = {
   isMyTurn: boolean;
@@ -12,7 +11,7 @@ const MAX_AMOUNT = 100000;
 
 function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
   const [betAmount, setBetAmount] = useState(bigBlind);
-  const [showChipDisplay, setShowChipDisplay] = useState(false);
+
   const [errorMessage, setErrorMessage] = useState('');
   const [allIn, setAllIn] = useState(false);
 
@@ -56,8 +55,6 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
     }
     setErrorMessage('');
 
-    setShowChipDisplay(true);
-
     const payload = { pokerTableName: 'table_1', amount: betAmount };
 
     const result = await apiCall.post('games.bet', payload);
@@ -65,7 +62,7 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
       // Do something with the error
       console.log(result?.error);
     }
-  }, [betAmount]);
+  }, [betAmount, bigBlind]);
 
   const snapToNearest = (value: number, increment: number) => {
     return Math.round(value / increment) * increment;
@@ -130,7 +127,6 @@ function Actions({ isMyTurn, bigBlind = 100 }: ActionsProps) {
           <button className="action-buttons" id="raise-action-button" aria-label="Bet" onClick={bet}>
             {allIn ? 'All In' : 'Bet'}
           </button>
-          {showChipDisplay && <ChipDisplay totalValue={betAmount} />}
         </div>
       )}
     </div>

--- a/frontend/src/components/PokerTable/PokerTable.tsx
+++ b/frontend/src/components/PokerTable/PokerTable.tsx
@@ -1,7 +1,14 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { selectActingSeat, selectHoleCards, selectMyUsername, selectSeats } from '../../store/selectors.ts';
+import {
+  selectActingSeat,
+  selectHoleCards,
+  selectMyUsername,
+  selectPlayersCurrentBets,
+  selectPot,
+  selectSeats,
+} from '../../store/selectors.ts';
 import { AppDispatch } from '../../store/store.tsx';
 import Actions from './Actions/Actions';
 import Board from './Board/Board';
@@ -29,13 +36,15 @@ export function PokerTable() {
   const holeCards = useSelector(selectHoleCards);
   const actingSeat = useSelector(selectActingSeat);
   const myUsername = useSelector(selectMyUsername);
+  const playersCurrentBets = useSelector(selectPlayersCurrentBets);
+  const pot = useSelector(selectPot);
 
   const isMyTurn = seats.value?.find((seat) => seat.seatNumber === actingSeat)?.username === myUsername;
 
   return (
     <>
       <div id="poker-table">
-        <Pot />
+        <Pot pot={pot} />
         <Board />
         {seats.value?.map((seat) => (
           <Seat
@@ -46,6 +55,7 @@ export function PokerTable() {
             chipCount={1000}
             cards={holeCards.value}
             isActingSeat={seat.seatNumber === actingSeat}
+            playersCurrentBets={playersCurrentBets}
           />
         ))}
       </div>

--- a/frontend/src/components/PokerTable/Pot/Pot.tsx
+++ b/frontend/src/components/PokerTable/Pot/Pot.tsx
@@ -1,8 +1,8 @@
-type PotProps = {};
+type PotProps = { pot: number };
 
-export default function Pot({}: PotProps) {
+export default function Pot({ pot }: PotProps) {
   return (
-    <div id="pot" data-chip-count="0">
+    <div id="pot" data-chip-count={pot}>
       Pot
     </div>
   );

--- a/frontend/src/components/PokerTable/Seat/Seat.tsx
+++ b/frontend/src/components/PokerTable/Seat/Seat.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Card as CardType } from '../../../../../backend/src/shared/game/types/Card';
 import { CardShortCode } from '../../../../../backend/src/shared/game/types/CardShortCode';
 import apiCall from '../../../fetch/apiCall';
 import { Card } from '../../Card/Card.tsx';
+import ChipDisplay from '../../Chips/ChipDisplay';
 import CountdownIndicator from '../../CountdownIndicator/CountdownIndicator.tsx';
 
 type SeatProps = {
@@ -13,15 +14,16 @@ type SeatProps = {
   seatUsername?: string;
   cards?: CardType[];
   isActingSeat?: boolean;
+  playersCurrentBets?: { currentBet: number; seatNumber: number; chipCount: number }[];
 };
 
 export default function Seat({
   seatNumber,
   myUsername,
   seatUsername,
-  chipCount,
   cards,
   isActingSeat,
+  playersCurrentBets,
 }: Readonly<SeatProps>) {
   const onPlayerSit = useCallback(async () => {
     const payload = { selectedSeatNumber: seatNumber };
@@ -41,6 +43,14 @@ export default function Seat({
       console.log(result?.error);
     }
   }, [seatNumber]);
+
+  const betAmount = useMemo(() => {
+    return playersCurrentBets?.find((player) => player.seatNumber === seatNumber)?.currentBet;
+  }, [seatNumber, playersCurrentBets]);
+
+  const chipCount = useMemo(() => {
+    return playersCurrentBets?.find((player) => player.seatNumber === seatNumber)?.chipCount;
+  }, [seatNumber, playersCurrentBets]);
 
   // Define a function to render the cards if the user is in the hand
   // TODO: will need to update this to show the cards if the user is actually in the hand
@@ -74,6 +84,7 @@ export default function Seat({
             <CountdownIndicator initialCount={10} duration={10000} />
           </div>
         )}
+        {betAmount && <ChipDisplay totalValue={betAmount} />}
       </button>
 
       {myUsername === seatUsername ? <button onClick={playerLeave}>Leave seat</button> : null}

--- a/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
+++ b/frontend/src/components/PokerTable/hooks/useSubscribeToGameEvents.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { useSocket } from '../../../hooks/useSocket';
-import { setActingSeat } from '../../../store/slices/gameStateSlice';
+import { resetBets, setActingSeat, setPlayerBet, setPot } from '../../../store/slices/gameStateSlice';
 import { setHoleCards } from '../../../store/slices/holeCardsSlice';
 import { addUser, removeUser } from '../../../store/slices/seatsSlice';
 import { AppDispatch } from '../../../store/store.tsx';
@@ -53,6 +53,22 @@ export function useSubscribeToGameEvents() {
       console.log('payload', payload);
       dispatch(setActingSeat(payload));
     });
+    const subscribeToUpdatePot = subscribeToEvent('update_pot', (payload) => {
+      console.log('Update pot');
+      console.log('payload', payload);
+      dispatch(setPot(payload));
+    });
+
+    const subscribePlayerBet = subscribeToEvent('player_bet', (payload) => {
+      console.log('Player bet');
+      console.log('payload', payload);
+      dispatch(setPlayerBet(payload));
+    });
+
+    const subscribeResetBets = subscribeToEvent('reset_bets', () => {
+      console.log('Reset pot');
+      dispatch(resetBets());
+    });
 
     return () => {
       subscribeToPlayerJoined();
@@ -61,6 +77,9 @@ export function useSubscribeToGameEvents() {
       subscribeToDealGame();
       subscribeToFoldCards();
       subscribeToSeatToAct();
+      subscribeToUpdatePot();
+      subscribePlayerBet();
+      subscribeResetBets();
     };
   }, [dispatch, subscribeToEvent]);
 }

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -29,3 +29,17 @@ export const selectActingSeat = createSelector(
     return gameState?.seatToAct;
   },
 );
+
+export const selectPlayersCurrentBets = createSelector(
+  (state: RootState) => state.gameStateSlice.value,
+  (gameState) => {
+    return gameState?.playersCurrentBets;
+  },
+);
+
+export const selectPot = createSelector(
+  (state: RootState) => state.gameStateSlice.value,
+  (gameState) => {
+    return gameState?.pot;
+  },
+);

--- a/frontend/src/store/slices/gameStateSlice.tsx
+++ b/frontend/src/store/slices/gameStateSlice.tsx
@@ -1,7 +1,11 @@
 import { PayloadAction, SerializedError, createSlice } from '@reduxjs/toolkit';
 
 import { GameState } from '../../../../backend/src/shared/game/types/GameState.ts';
-import { SeatToActEvent } from '../../../../backend/src/shared/websockets/game/types/GameEvents.ts';
+import {
+  PlayerBetEvent,
+  SeatToActEvent,
+  UpdatePotEvent,
+} from '../../../../backend/src/shared/websockets/game/types/GameEvents.ts';
 import fetchGameState from '../../components/PokerTable/thunks/fetchGameState';
 
 interface GameStateSlice {
@@ -31,6 +35,33 @@ export const gameStateSlice = createSlice({
       }
       state.value.seatToAct = action.payload.seatToAct;
     },
+    setPot: (state, action: PayloadAction<UpdatePotEvent>) => {
+      if (state.value === null) {
+        return;
+      }
+      state.value.pot = action.payload.pot;
+    },
+    setPlayerBet: (state, action: PayloadAction<PlayerBetEvent>) => {
+      if (state.value === null) {
+        return;
+      }
+
+      state.value.playersCurrentBets = state.value.playersCurrentBets.map(
+        (player: { currentBet: number; seatNumber: number }) =>
+          player.seatNumber === action.payload.seatNumber
+            ? { ...player, currentBet: action.payload.betAmount, chipCount: action.payload.chipCount }
+            : player,
+      );
+    },
+    resetBets: (state) => {
+      if (state.value === null) {
+        return;
+      }
+
+      state.value.playersCurrentBets = state.value.playersCurrentBets.map(
+        (player: { currentBet: number; seatNumber: number }) => ({ ...player, currentBet: 0 }),
+      );
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -48,6 +79,6 @@ export const gameStateSlice = createSlice({
   },
 });
 
-export const { setActingSeat } = gameStateSlice.actions;
+export const { setActingSeat, setPot, setPlayerBet, resetBets } = gameStateSlice.actions;
 
 export default gameStateSlice.reducer;


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->

This PR adds the chip logic for the front end and displays chip count and pot accordingly throughout the rounds.


### Task

<!---
- Task link from ClickUp (found on the right through Copy link)
- Task ID from ClickUp (find the id and add CU- as a prefix like CU-123456 )
--->

[CU-86cw08ca9](https://app.clickup.com/t/86cw08ca9)
<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
