### PR TITLE
feat: update getGameState to return chip counts

### DIFF
--- a/backend/src/game/Dealer.ts
+++ b/backend/src/game/Dealer.ts
@@ -9,6 +9,8 @@ import { Result } from '../infra/Result';
 import { Game } from './Game';
 import { PokerTable } from './PokerTable';
 
+type PlayersCurrentBets = { seatNumber: number; currentBet: number; chipCount: number };
+
 export class Dealer {
   public static newGame(pokerTable: PokerTable) {
     const smallBlind = 1;
@@ -135,5 +137,21 @@ export class Dealer {
     }
 
     return [];
+  }
+
+  public static getCurrentBets(pokerTable: PokerTable): PlayersCurrentBets[] {
+    const playersCurrentBets: PlayersCurrentBets[] = [];
+    pokerTable.getSeats().forEach((seat) => {
+      const player = seat.getPlayer();
+      if (player) {
+        playersCurrentBets.push({
+          chipCount: player.getChipCount(),
+          seatNumber: seat.getSeatNumber(),
+          currentBet: player.getCurrentBet(),
+        });
+      }
+    });
+
+    return playersCurrentBets;
   }
 }

--- a/backend/src/game/Player.ts
+++ b/backend/src/game/Player.ts
@@ -3,9 +3,13 @@ import { User } from '../users/User';
 
 export class Player extends User {
   private cards: Card[] = [];
+  private chipCount: number;
+  private currentBet: number;
 
   constructor(userId: number, username: string) {
     super(userId, username);
+    this.chipCount = 1000;
+    this.currentBet = 0;
   }
 
   public setCards(cards: Card[]): void {
@@ -18,5 +22,13 @@ export class Player extends User {
 
   public foldCards(): void {
     this.cards = [];
+  }
+
+  public getCurrentBet(): number {
+    return this.currentBet;
+  }
+
+  public getChipCount(): number {
+    return this.chipCount;
   }
 }

--- a/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
+++ b/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.test.ts
@@ -14,7 +14,7 @@ describe('games.getGameState', () => {
     expect(res.body.error.errorCode).toBe('INVALID_REQUEST_PAYLOAD');
   });
 
-  it('should return method_not_implemented', async () => {
+  it('should return GAME_STATE_DOES_NOT_EXIST', async () => {
     mockMySqlSelectSessionSuccess('userone');
 
     const res = await apiTest('/api/games.getGameState', {

--- a/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.ts
+++ b/backend/src/handlers/games/getGameState/GamesGetGameStateHandler.ts
@@ -23,11 +23,15 @@ export class GamesGetGameStateHandler extends AbstractGamesGetGameStateHandler {
     // TODO: perhaps in future we have own endpoint and make the getGameStateHandler not authentication needed
     const playersHoleCards = Dealer.getPlayersHoleCards(pokerTable, userId);
 
+    // TODO: currentbets should be in the gameState and shouldn't be named playersCurrentBets
+    const playersCurrentBets = Dealer.getCurrentBets(pokerTable);
+
     const resp = {
       ok: true,
       payload: {
         ...gameState,
         playersHoleCards: playersHoleCards,
+        playersCurrentBets: playersCurrentBets,
       },
     };
 

--- a/backend/src/shared/api/gen/games/schemas/GamesGetGameStateSchemas.ts
+++ b/backend/src/shared/api/gen/games/schemas/GamesGetGameStateSchemas.ts
@@ -21,6 +21,15 @@ export const GamesGetGameStateOutputSchema = Joi.object<GamesGetGameStateOutput>
       .required(),
     currentBet: Joi.number().required(),
     dealerPosition: Joi.number().required(),
+    playersCurrentBets: Joi.array()
+      .items(
+        Joi.object({
+          chipCount: Joi.number().required(),
+          currentBet: Joi.number().required(),
+          seatNumber: Joi.number().required(),
+        }),
+      )
+      .required(),
     playersHoleCards: Joi.array()
       .items(
         Joi.object({

--- a/backend/src/shared/api/gen/games/types/GamesGetGameState.ts
+++ b/backend/src/shared/api/gen/games/types/GamesGetGameState.ts
@@ -15,6 +15,11 @@ export interface GamesGetGameStateOutput extends BaseOutput {
     }[];
     currentBet: number;
     dealerPosition: number;
+    playersCurrentBets: {
+      chipCount: number;
+      currentBet: number;
+      seatNumber: number;
+    }[];
     playersHoleCards: {
       cardShortCode: string;
       rank: string;

--- a/backend/src/shared/api/metadata/games_getGameState.json
+++ b/backend/src/shared/api/metadata/games_getGameState.json
@@ -111,6 +111,19 @@
               ],
               "allowEmpty": true
             }
+          },
+          {
+            "name": "playersCurrentBets",
+            "type": "array",
+            "required": true,
+            "items": {
+              "type": "object",
+              "properties": [
+                { "name": "seatNumber", "type": "number", "required": true },
+                { "name": "currentBet", "type": "number", "required": true },
+                { "name": "chipCount", "type": "number", "required": true }
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
### Description

<!--- What Why How... you made this change --->
This PR updates the games.getGameState handler to return chip counts for each player to display. This is so the FE can reload and see all current bets.


### Task

[86cw08ch7](https://app.clickup.com/t/86cw08ch7)

<!---
- Don't forget to add learning objectives to the PR: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

- Don't forget to add a reviewer on the right, and yourself as the assignee
--->
